### PR TITLE
Create endpoint to resend email verification link

### DIFF
--- a/src/main/java/br/com/conectabyte/profissu/config/SecurityConfig.java
+++ b/src/main/java/br/com/conectabyte/profissu/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
     http
         .csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(authorize -> authorize
-            .requestMatchers(HttpMethod.POST, "/auth/*").permitAll()
+            .requestMatchers(HttpMethod.POST, "/auth/**").permitAll()
             .requestMatchers(HttpMethod.GET, swaggerEndpoints).permitAll()
             .requestMatchers(HttpMethod.GET, staticResources).permitAll()
             .anyRequest().authenticated())

--- a/src/main/java/br/com/conectabyte/profissu/controllers/AuthController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/AuthController.java
@@ -7,12 +7,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import br.com.conectabyte.profissu.dtos.EmailValueRequestDto;
 import br.com.conectabyte.profissu.dtos.ExceptionDto;
 import br.com.conectabyte.profissu.dtos.LoginRequestDto;
 import br.com.conectabyte.profissu.dtos.LoginResponseDto;
-import br.com.conectabyte.profissu.dtos.PasswordRecoveryRequestDto;
+import br.com.conectabyte.profissu.dtos.MessageValueResponseDto;
 import br.com.conectabyte.profissu.dtos.ResetPasswordRequestDto;
-import br.com.conectabyte.profissu.dtos.ResetPasswordResponseDto;
+import br.com.conectabyte.profissu.dtos.SignUpConfirmationRequestDto;
 import br.com.conectabyte.profissu.dtos.UserRequestDto;
 import br.com.conectabyte.profissu.dtos.UserResponseDto;
 import br.com.conectabyte.profissu.services.LoginService;
@@ -50,21 +51,34 @@ public class AuthController {
     return ResponseEntity.status(HttpStatus.CREATED).body(this.userService.register(user));
   }
 
+  @PostMapping("/sign-up-confirmation")
+  public ResponseEntity<MessageValueResponseDto> signUpConfirmation(
+      @Valid @RequestBody SignUpConfirmationRequestDto signUpConfirmationRequestDto) {
+    final var response = this.userService.signUpConfirmation(signUpConfirmationRequestDto);
+    return ResponseEntity.status(response.responseCode()).body(response);
+  }
+
+  @PostMapping("/sign-up-confirmation/resend")
+  public ResponseEntity<Void> resendSignUpConfirmation(@Valid @RequestBody EmailValueRequestDto emailValueRequestDto) {
+    this.userService.resendSignUpConfirmation(emailValueRequestDto);
+    return ResponseEntity.accepted().build();
+  }
+
   @Operation(summary = "Recover password", description = "Receives password recovery requests", responses = {
       @ApiResponse(responseCode = "201", description = "Password recovery request successfully received.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Void.class)))
   })
   @PostMapping("/password-recovery")
-  public ResponseEntity<Void> recoverPassword(@Valid @RequestBody PasswordRecoveryRequestDto passwordRecoveryDto) {
-    this.userService.recoverPassword(passwordRecoveryDto);
+  public ResponseEntity<Void> recoverPassword(@Valid @RequestBody EmailValueRequestDto emailValueRequestDto) {
+    this.userService.recoverPassword(emailValueRequestDto);
     return ResponseEntity.accepted().build();
   }
 
   @Operation(summary = "Reset password", description = "Receives password reset requests", responses = {
-      @ApiResponse(responseCode = "200", description = "Password was successfully reset.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResetPasswordResponseDto.class))),
-      @ApiResponse(responseCode = "400", description = "Password was not reset.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResetPasswordResponseDto.class)))
+      @ApiResponse(responseCode = "200", description = "Password was successfully reset.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageValueResponseDto.class))),
+      @ApiResponse(responseCode = "400", description = "Password was not reset.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageValueResponseDto.class)))
   })
   @PostMapping("/password-reset")
-  public ResponseEntity<ResetPasswordResponseDto> resetPassword(
+  public ResponseEntity<MessageValueResponseDto> resetPassword(
       @Valid @RequestBody ResetPasswordRequestDto resetPasswordRequestDto) {
     final var response = this.userService.resetPassword(resetPasswordRequestDto);
     return ResponseEntity.status(response.responseCode()).body(response);

--- a/src/main/java/br/com/conectabyte/profissu/controllers/AuthController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/AuthController.java
@@ -62,6 +62,9 @@ public class AuthController {
     return ResponseEntity.status(response.responseCode()).body(response);
   }
 
+  @Operation(summary = "Resend sign-up confirmation", description = "Receives resend sign-up confirmation requests", responses = {
+      @ApiResponse(responseCode = "201", description = "Resend sign-up confirmation request successfully received.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Void.class)))
+  })
   @PostMapping("/sign-up-confirmation/resend")
   public ResponseEntity<Void> resendSignUpConfirmation(@Valid @RequestBody EmailValueRequestDto emailValueRequestDto) {
     this.userService.resendSignUpConfirmation(emailValueRequestDto);

--- a/src/main/java/br/com/conectabyte/profissu/controllers/AuthController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/AuthController.java
@@ -51,6 +51,10 @@ public class AuthController {
     return ResponseEntity.status(HttpStatus.CREATED).body(this.userService.register(user));
   }
 
+  @Operation(summary = "Sign-up confirmation", description = "Receives sign-up confirmation requests", responses = {
+      @ApiResponse(responseCode = "200", description = "Sign-up was successfully confirmated.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageValueResponseDto.class))),
+      @ApiResponse(responseCode = "400", description = "Sign-up was not confirmated.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageValueResponseDto.class)))
+  })
   @PostMapping("/sign-up-confirmation")
   public ResponseEntity<MessageValueResponseDto> signUpConfirmation(
       @Valid @RequestBody SignUpConfirmationRequestDto signUpConfirmationRequestDto) {

--- a/src/main/java/br/com/conectabyte/profissu/controllers/AuthController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/AuthController.java
@@ -47,7 +47,7 @@ public class AuthController {
   })
   @PostMapping("/register")
   public ResponseEntity<UserResponseDto> register(@Valid @RequestBody UserRequestDto user) {
-    return ResponseEntity.status(HttpStatus.CREATED).body(this.userService.save(user));
+    return ResponseEntity.status(HttpStatus.CREATED).body(this.userService.register(user));
   }
 
   @Operation(summary = "Recover password", description = "Receives password recovery requests", responses = {

--- a/src/main/java/br/com/conectabyte/profissu/dtos/EmailValueRequestDto.java
+++ b/src/main/java/br/com/conectabyte/profissu/dtos/EmailValueRequestDto.java
@@ -3,6 +3,6 @@ package br.com.conectabyte.profissu.dtos;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
-public record PasswordRecoveryRequestDto(
+public record EmailValueRequestDto(
     @NotBlank(message = "email: Cannot be null or empty") @Pattern(regexp = "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$", message = "email: Must be a valid email address") String email) {
 }

--- a/src/main/java/br/com/conectabyte/profissu/dtos/MessageValueResponseDto.java
+++ b/src/main/java/br/com/conectabyte/profissu/dtos/MessageValueResponseDto.java
@@ -2,5 +2,5 @@ package br.com.conectabyte.profissu.dtos;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-public record ResetPasswordResponseDto(@JsonIgnore Integer responseCode, String message) {
+public record MessageValueResponseDto(@JsonIgnore Integer responseCode, String message) {
 }

--- a/src/main/java/br/com/conectabyte/profissu/dtos/ResetPasswordRequestDto.java
+++ b/src/main/java/br/com/conectabyte/profissu/dtos/ResetPasswordRequestDto.java
@@ -9,5 +9,5 @@ import jakarta.validation.constraints.Pattern;
 public record ResetPasswordRequestDto(
     @Email(message = "email: Must be a valid email address") @NotBlank(message = "email: Cannot be null or empty") String email,
     @NotBlank(message = "password: Cannot be null or empty") @Length(min = 8, message = "password: Must have at least 8 characters") @Pattern(regexp = "^(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>])[A-Za-z\\d!@#$%^&*(),.?\":{}|<>]{8,}$", message = "password: Must contain at least one uppercase letter, one digit, and one special character") String password,
-    @NotBlank(message = "resetCode: Cannot be null or empty") String resetCode) {
+    @NotBlank(message = "code: Cannot be null or empty") String code) {
 }

--- a/src/main/java/br/com/conectabyte/profissu/dtos/SignUpConfirmationRequestDto.java
+++ b/src/main/java/br/com/conectabyte/profissu/dtos/SignUpConfirmationRequestDto.java
@@ -5,5 +5,5 @@ import jakarta.validation.constraints.NotBlank;
 
 public record SignUpConfirmationRequestDto(
     @Email(message = "email: Must be a valid email address") @NotBlank(message = "email: Cannot be null or empty") String email,
-    @NotBlank(message = "resetCode: Cannot be null or empty") String resetCode) {
+    @NotBlank(message = "code: Cannot be null or empty") String code) {
 }

--- a/src/main/java/br/com/conectabyte/profissu/dtos/SignUpConfirmationRequestDto.java
+++ b/src/main/java/br/com/conectabyte/profissu/dtos/SignUpConfirmationRequestDto.java
@@ -1,0 +1,9 @@
+package br.com.conectabyte.profissu.dtos;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SignUpConfirmationRequestDto(
+    @Email(message = "email: Must be a valid email address") @NotBlank(message = "email: Cannot be null or empty") String email,
+    @NotBlank(message = "resetCode: Cannot be null or empty") String resetCode) {
+}

--- a/src/main/java/br/com/conectabyte/profissu/services/EmailService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/EmailService.java
@@ -1,15 +1,20 @@
 package br.com.conectabyte.profissu.services;
 
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailService {
@@ -19,20 +24,57 @@ public class EmailService {
   @Value("${profissu.url}")
   private String profissuUrl;
 
-  public void sendPasswordRecoveryEmail(String email, String resetCode) throws MessagingException {
+  private final String LOGO_PATH = "/images/profissu.jpeg";
+
+  record SendEmailDto(String email, String subject, String templateName, Map<String, String> variables) {
+  }
+
+  private void sendEmail(SendEmailDto sendEmailDto) throws MessagingException {
     final var message = javaMailSender.createMimeMessage();
     final var helper = new MimeMessageHelper(message, true);
     final var context = new Context();
-    final var profissuLogoUrl = profissuUrl + "/images/profissu.jpeg";
 
-    helper.setTo(email);
-    helper.setSubject("Password Recovery - Profisu");
-    context.setVariable("profissuLogoUrl", profissuLogoUrl);
-    context.setVariable("resetCode", resetCode);
-    
-    final var htmlContent = templateEngine.process("email-recovery", context);
+    sendEmailDto.variables().forEach(context::setVariable);
+
+    final var htmlContent = templateEngine.process(sendEmailDto.templateName(), context);
+
+    helper.setTo(sendEmailDto.email());
+    helper.setSubject(sendEmailDto.subject());
     helper.setText(htmlContent, true);
 
     javaMailSender.send(message);
   }
+
+  public void sendPasswordRecoveryEmail(String email, String resetCode) throws MessagingException {
+    final var variables = Map.of(
+        "profissuLogoUrl", profissuUrl + LOGO_PATH,
+        "resetCode", resetCode,
+        "emailTitle", "Password Recovery",
+        "emailMessage",
+        "We received a request to reset your password. Please use the following code to create a new password.",
+        "footerMessage", "If you didn't request this, you can safely ignore this email.");
+    final var sendEmailDto = new SendEmailDto(email, "Password Recovery - Profisu", "code-verification-email.html",
+        variables);
+
+    sendEmail(sendEmailDto);
+  }
+
+  @Async
+  public void sendSignUpConfirmation(String email, String confirmationCode) {
+    final var variables = Map.of(
+        "profissuLogoUrl", profissuUrl + LOGO_PATH,
+        "resetCode", confirmationCode,
+        "emailTitle", "Sign Up Confirmation",
+        "emailMessage", "Thank you for signing up for Profisu! Please use the code below to confirm your registration:",
+        "footerMessage", "If you did not sign up, you can safely ignore this email.");
+    final var sendEmailDto = new SendEmailDto(email, "Sign Up Confirmation - Profisu", "code-verification-email.html",
+        variables);
+
+    try {
+      sendEmail(sendEmailDto);
+    } catch (MessagingException e) {
+      log.error("Failed to send e-mail to {}: {}", email, e.getMessage());
+    }
+  }
+
 }

--- a/src/main/java/br/com/conectabyte/profissu/services/EmailService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/EmailService.java
@@ -45,10 +45,10 @@ public class EmailService {
     javaMailSender.send(message);
   }
 
-  public void sendPasswordRecoveryEmail(String email, String resetCode) throws MessagingException {
+  public void sendPasswordRecoveryEmail(String email, String code) throws MessagingException {
     final var variables = Map.of(
         "profissuLogoUrl", profissuUrl + LOGO_PATH,
-        "resetCode", resetCode,
+        "code", code,
         "emailTitle", "Password Recovery",
         "emailMessage",
         "We received a request to reset your password. Please use the following code to create a new password.",
@@ -60,10 +60,10 @@ public class EmailService {
   }
 
   @Async
-  public void sendSignUpConfirmation(String email, String confirmationCode) {
+  public void sendSignUpConfirmation(String email, String code) {
     final var variables = Map.of(
         "profissuLogoUrl", profissuUrl + LOGO_PATH,
-        "resetCode", confirmationCode,
+        "code", code,
         "emailTitle", "Sign Up Confirmation",
         "emailMessage", "Thank you for signing up for Profisu! Please use the code below to confirm your registration:",
         "footerMessage", "If you did not sign up, you can safely ignore this email.");
@@ -76,5 +76,4 @@ public class EmailService {
       log.error("Failed to send e-mail to {}: {}", email, e.getMessage());
     }
   }
-
 }

--- a/src/main/java/br/com/conectabyte/profissu/services/TokenService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/TokenService.java
@@ -1,5 +1,6 @@
 package br.com.conectabyte.profissu.services;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import br.com.conectabyte.profissu.entities.Token;
@@ -30,5 +31,14 @@ public class TokenService {
     token.getUser().setToken(null);
 
     this.delete(token);
+  }
+
+  public void save(User user, String resetCode, PasswordEncoder passwordEncoder) {
+    final var token = Token.builder()
+        .value(passwordEncoder.encode(resetCode))
+        .user(user)
+        .build();
+    this.deleteByUser(user);
+    this.save(token);
   }
 }

--- a/src/main/java/br/com/conectabyte/profissu/services/TokenService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/TokenService.java
@@ -33,9 +33,9 @@ public class TokenService {
     this.delete(token);
   }
 
-  public void save(User user, String resetCode, PasswordEncoder passwordEncoder) {
+  public void save(User user, String code, PasswordEncoder passwordEncoder) {
     final var token = Token.builder()
-        .value(passwordEncoder.encode(resetCode))
+        .value(passwordEncoder.encode(code))
         .user(user)
         .build();
     this.deleteByUser(user);

--- a/src/main/resources/templates/code-verification-email.html
+++ b/src/main/resources/templates/code-verification-email.html
@@ -80,7 +80,7 @@
     <p>Hello,</p>
     <p th:text="${emailMessage}">Default message</p>
     <div class="code-container">
-      <span th:text="${resetCode}">000000</span>
+      <span th:text="${code}"></span>
     </div>
     <p th:text="${footerMessage}">Default footer message</p>
     <div class="footer">

--- a/src/main/resources/templates/code-verification-email.html
+++ b/src/main/resources/templates/code-verification-email.html
@@ -3,8 +3,9 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Password Recovery - Profisu</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&family=Quicksand:wght@500&display=swap" rel="stylesheet">
+  <title th:text="${emailTitle}">Profisu Email</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&family=Quicksand:wght@500&display=swap"
+    rel="stylesheet">
   <style>
     body {
       font-family: 'Poppins', sans-serif;
@@ -33,10 +34,6 @@
       font-size: 4em;
       color: #333;
       letter-spacing: 1em;
-
-      span {
-        margin-left: 1em;
-      }
     }
 
     .logo {
@@ -79,13 +76,13 @@
 <body>
   <div class="container">
     <img th:src="${profissuLogoUrl}" alt="Profisu Logo" class="logo">
-    <h1>Password Recovery</h1>
+    <h1 th:text="${emailTitle}">Profisu Email</h1>
     <p>Hello,</p>
-    <p>We received a request to reset your password. Please use the following code to create a new password.</p>
+    <p th:text="${emailMessage}">Default message</p>
     <div class="code-container">
-      <span th:text="${resetCode}"></span>
+      <span th:text="${resetCode}">000000</span>
     </div>
-    <p>If you didn't request this, you can safely ignore this email.</p>
+    <p th:text="${footerMessage}">Default footer message</p>
     <div class="footer">
       <p>&copy; 2025 Conecta Byte. All rights reserved.</p>
       <p>Need help? <a href="mailto:support@conectabyte.com.br">Contact our support</a></p>

--- a/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
@@ -138,7 +138,7 @@ public class AuthControllerTest {
     user.setAddresses(List.of(AddressUtils.create(user)));
     user.setId(1L);
     user.setProfile(new Profile());
-    when(userService.save(any(UserRequestDto.class))).thenReturn(userMapper.userToUserResponseDto(user));
+    when(userService.register(any(UserRequestDto.class))).thenReturn(userMapper.userToUserResponseDto(user));
 
     mockMvc.perform(post("/auth/register")
         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
@@ -23,11 +23,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import br.com.conectabyte.profissu.dtos.EmailValueRequestDto;
 import br.com.conectabyte.profissu.dtos.LoginRequestDto;
 import br.com.conectabyte.profissu.dtos.LoginResponseDto;
-import br.com.conectabyte.profissu.dtos.PasswordRecoveryRequestDto;
+import br.com.conectabyte.profissu.dtos.MessageValueResponseDto;
 import br.com.conectabyte.profissu.dtos.ResetPasswordRequestDto;
-import br.com.conectabyte.profissu.dtos.ResetPasswordResponseDto;
 import br.com.conectabyte.profissu.dtos.UserRequestDto;
 import br.com.conectabyte.profissu.entities.Profile;
 import br.com.conectabyte.profissu.entities.User;
@@ -169,22 +169,22 @@ public class AuthControllerTest {
 
   @Test
   void shouldAcceptPasswordRecoveryRequestWhenEmailIsValid() throws Exception {
-    final var passwordRecoveryRequestDto = new PasswordRecoveryRequestDto("test@conectabyte.com.br");
+    final var emailValueRequestDto = new EmailValueRequestDto("test@conectabyte.com.br");
     doNothing().when(userService).recoverPassword(any());
 
     mockMvc.perform(post("/auth/password-recovery")
         .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(passwordRecoveryRequestDto)))
+        .content(objectMapper.writeValueAsString(emailValueRequestDto)))
         .andExpect(status().isAccepted());
   }
 
   @Test
   void shouldReturnBadRequestWhenPasswordRecoveryEmailIsMissing() throws Exception {
-    final var passwordRecoveryRequestDto = new PasswordRecoveryRequestDto(null);
+    final var emailValueRequestDto = new EmailValueRequestDto(null);
 
     mockMvc.perform(post("/auth/password-recovery")
         .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(passwordRecoveryRequestDto)))
+        .content(objectMapper.writeValueAsString(emailValueRequestDto)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("All fields must be valid"));
   }
@@ -193,7 +193,7 @@ public class AuthControllerTest {
   void shouldResetPasswordSuccessfullyWhenDataIsValid() throws Exception {
     final var pesetPasswordRequestDto = new ResetPasswordRequestDto("test@conectabyte.com.br", "@Admin123", "CODE");
     when(userService.resetPassword(any()))
-        .thenReturn(new ResetPasswordResponseDto(HttpStatus.OK.value(), "Password was updated."));
+        .thenReturn(new MessageValueResponseDto(HttpStatus.OK.value(), "Password was updated."));
 
     mockMvc.perform(post("/auth/password-reset")
         .contentType(MediaType.APPLICATION_JSON)
@@ -206,7 +206,7 @@ public class AuthControllerTest {
   void shouldReturnBadRequestWhenResetCodeIsInvalid() throws Exception {
     final var pesetPasswordRequestDto = new ResetPasswordRequestDto("invalid@conectabyte.com.br", "@Admin123", "CODE");
     when(userService.resetPassword(any()))
-        .thenReturn(new ResetPasswordResponseDto(HttpStatus.BAD_REQUEST.value(), "Reset code is invalid."));
+        .thenReturn(new MessageValueResponseDto(HttpStatus.BAD_REQUEST.value(), "Reset code is invalid."));
 
     mockMvc.perform(post("/auth/password-reset")
         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
@@ -28,6 +28,7 @@ import br.com.conectabyte.profissu.dtos.LoginRequestDto;
 import br.com.conectabyte.profissu.dtos.LoginResponseDto;
 import br.com.conectabyte.profissu.dtos.MessageValueResponseDto;
 import br.com.conectabyte.profissu.dtos.ResetPasswordRequestDto;
+import br.com.conectabyte.profissu.dtos.SignUpConfirmationRequestDto;
 import br.com.conectabyte.profissu.dtos.UserRequestDto;
 import br.com.conectabyte.profissu.entities.Profile;
 import br.com.conectabyte.profissu.entities.User;
@@ -191,59 +192,129 @@ public class AuthControllerTest {
 
   @Test
   void shouldResetPasswordSuccessfullyWhenDataIsValid() throws Exception {
-    final var pesetPasswordRequestDto = new ResetPasswordRequestDto("test@conectabyte.com.br", "@Admin123", "CODE");
+    final var resetPasswordRequestDto = new ResetPasswordRequestDto("test@conectabyte.com.br", "@Admin123", "CODE");
     when(userService.resetPassword(any()))
         .thenReturn(new MessageValueResponseDto(HttpStatus.OK.value(), "Password was updated."));
 
     mockMvc.perform(post("/auth/password-reset")
         .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(pesetPasswordRequestDto)))
+        .content(objectMapper.writeValueAsString(resetPasswordRequestDto)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.message").value("Password was updated."));
   }
 
   @Test
-  void shouldReturnBadRequestWhenResetCodeIsInvalid() throws Exception {
-    final var pesetPasswordRequestDto = new ResetPasswordRequestDto("invalid@conectabyte.com.br", "@Admin123", "CODE");
+  void shouldReturnBadRequestWhenCodeIsInvalid() throws Exception {
+    final var resetPasswordRequestDto = new ResetPasswordRequestDto("invalid@conectabyte.com.br", "@Admin123", "CODE");
     when(userService.resetPassword(any()))
         .thenReturn(new MessageValueResponseDto(HttpStatus.BAD_REQUEST.value(), "Reset code is invalid."));
 
     mockMvc.perform(post("/auth/password-reset")
         .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(pesetPasswordRequestDto)))
+        .content(objectMapper.writeValueAsString(resetPasswordRequestDto)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("Reset code is invalid."));
   }
 
   @Test
   void shouldReturnBadRequestWhenResetEmailIsMissing() throws Exception {
-    final var pesetPasswordRequestDto = new ResetPasswordRequestDto(null, "@Admin123", "CODE");
+    final var resetPasswordRequestDto = new ResetPasswordRequestDto(null, "@Admin123", "CODE");
 
     mockMvc.perform(post("/auth/password-reset")
         .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(pesetPasswordRequestDto)))
+        .content(objectMapper.writeValueAsString(resetPasswordRequestDto)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("All fields must be valid"));
   }
 
   @Test
   void shouldReturnBadRequestWhenResetPasswordIsMissing() throws Exception {
-    final var pesetPasswordRequestDto = new ResetPasswordRequestDto("test@conectabyte.com.br", null, "CODE");
+    final var resetPasswordRequestDto = new ResetPasswordRequestDto("test@conectabyte.com.br", null, "CODE");
 
     mockMvc.perform(post("/auth/password-reset")
         .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(pesetPasswordRequestDto)))
+        .content(objectMapper.writeValueAsString(resetPasswordRequestDto)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("All fields must be valid"));
   }
 
   @Test
-  void shouldReturnBadRequestWhenResetCodeIsMissing() throws Exception {
-    final var pesetPasswordRequestDto = new ResetPasswordRequestDto("test@conectabyte.com.br", "@Admin123", null);
+  void shouldReturnBadRequestWhenCodeIsMissing() throws Exception {
+    final var resetPasswordRequestDto = new ResetPasswordRequestDto("test@conectabyte.com.br", "@Admin123", null);
 
     mockMvc.perform(post("/auth/password-reset")
         .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(pesetPasswordRequestDto)))
+        .content(objectMapper.writeValueAsString(resetPasswordRequestDto)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("All fields must be valid"));
+  }
+
+  @Test
+  void shouldConfirmSignupSuccessfullyWhenDataIsValid() throws Exception {
+    final var signUpConfirmationRequestDto = new SignUpConfirmationRequestDto("test@conectabyte.com.br", "CODE");
+    when(userService.signUpConfirmation(any()))
+        .thenReturn(new MessageValueResponseDto(HttpStatus.OK.value(), "Sign up was confirmed."));
+
+    mockMvc.perform(post("/auth/sign-up-confirmation")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(signUpConfirmationRequestDto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("Sign up was confirmed."));
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenSignupCodeIsInvalid() throws Exception {
+    final var signUpConfirmationRequestDto = new SignUpConfirmationRequestDto("test@conectabyte.com.br", "CODE");
+    when(userService.signUpConfirmation(any()))
+        .thenReturn(new MessageValueResponseDto(HttpStatus.BAD_REQUEST.value(), "Reset code is invalid."));
+
+    mockMvc.perform(post("/auth/sign-up-confirmation")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(signUpConfirmationRequestDto)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("Reset code is invalid."));
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenSignupResetEmailIsMissing() throws Exception {
+    final var signUpConfirmationRequestDto = new SignUpConfirmationRequestDto(null, "CODE");
+
+    mockMvc.perform(post("/auth/sign-up-confirmation")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(signUpConfirmationRequestDto)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("All fields must be valid"));
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenSignupCodeIsMissing() throws Exception {
+    final var signUpConfirmationRequestDto = new SignUpConfirmationRequestDto("test@conectabyte.com.br", null);
+
+    mockMvc.perform(post("/auth/sign-up-confirmation")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(signUpConfirmationRequestDto)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("All fields must be valid"));
+  }
+
+  @Test
+  void shouldAcceptSignUpConfirmationResendRequestWhenEmailIsValid() throws Exception {
+    final var emailValueRequestDto = new EmailValueRequestDto("test@conectabyte.com.br");
+    doNothing().when(userService).resendSignUpConfirmation(any());
+
+    mockMvc.perform(post("/auth/sign-up-confirmation/resend")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(emailValueRequestDto)))
+        .andExpect(status().isAccepted());
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenSignUpConfirmationResendEmailIsMissing() throws Exception {
+    final var emailValueRequestDto = new EmailValueRequestDto(null);
+
+    mockMvc.perform(post("/auth/sign-up-confirmation/resend")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(emailValueRequestDto)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value("All fields must be valid"));
   }

--- a/src/test/java/br/com/conectabyte/profissu/services/EmailServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/EmailServiceTest.java
@@ -43,4 +43,19 @@ class EmailServiceTest {
     verify(javaMailSender, times(1)).send(mimeMessage);
     verify(templateEngine, times(1)).process(any(String.class), any(Context.class));
   }
+
+  @Test
+  void shouldSendSignUpConfirmationEmailSuccessfully() throws MessagingException {
+    final var htmlContent = "<html><body>Reset Code: 123456</body></html>";
+    final var mimeMessage = mock(MimeMessage.class);
+
+    when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+    when(templateEngine.process(any(String.class), any(Context.class))).thenReturn(htmlContent);
+
+    emailService.sendSignUpConfirmation("test@conectabyte.com.br", "CODE");
+
+    verify(javaMailSender, times(1)).createMimeMessage();
+    verify(javaMailSender, times(1)).send(mimeMessage);
+    verify(templateEngine, times(1)).process(any(String.class), any(Context.class));
+  }
 }

--- a/src/test/java/br/com/conectabyte/profissu/services/JwtServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/JwtServiceTest.java
@@ -32,7 +32,7 @@ public class JwtServiceTest {
     final var user = UserUtils.create();
     final var map = Map.of("key", new Object());
 
-    user.setRoles((Set.of(RoleUtils.createRole())));
+    user.setRoles((Set.of(RoleUtils.create())));
     user.setId(1L);
     when(jwtEncoder.encode(any())).thenReturn(new Jwt("TOKEN", Instant.now(), Instant.now(), map, map));
 

--- a/src/test/java/br/com/conectabyte/profissu/services/LoginServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/LoginServiceTest.java
@@ -32,7 +32,7 @@ public class LoginServiceTest {
   private UserService userService;
 
   @MockBean
-  private BCryptPasswordEncoder passwordEncoder;
+  private BCryptPasswordEncoder bCryptPasswordEncoder;
 
   @Autowired
   private LoginService loginService;
@@ -49,7 +49,7 @@ public class LoginServiceTest {
 
     when(jwtService.createJwtToken(any())).thenReturn(new LoginResponseDto(token, expiresIn));
     when(userService.findByEmail(any())).thenReturn(Optional.of(user));
-    when(passwordEncoder.matches(any(), any())).thenReturn(true);
+    when(bCryptPasswordEncoder.matches(any(), any())).thenReturn(true);
 
     final var loginResponseDto = loginService.login(new LoginRequestDto(email, password));
 
@@ -66,7 +66,7 @@ public class LoginServiceTest {
 
     when(jwtService.createJwtToken(any())).thenReturn(new LoginResponseDto(token, expiresIn));
     when(userService.findByEmail(any())).thenReturn(Optional.empty());
-    when(passwordEncoder.matches(any(), any())).thenReturn(true);
+    when(bCryptPasswordEncoder.matches(any(), any())).thenReturn(true);
 
     assertThrows(BadCredentialsException.class, () -> loginService.login(new LoginRequestDto(email, password)));
   }
@@ -80,7 +80,7 @@ public class LoginServiceTest {
 
     when(jwtService.createJwtToken(any())).thenReturn(new LoginResponseDto(token, expiresIn));
     when(userService.findByEmail(any())).thenReturn(Optional.of(UserUtils.create()));
-    when(passwordEncoder.matches(any(), any())).thenReturn(false);
+    when(bCryptPasswordEncoder.matches(any(), any())).thenReturn(false);
 
     assertThrows(BadCredentialsException.class, () -> loginService.login(new LoginRequestDto(email, password)));
   }
@@ -98,7 +98,7 @@ public class LoginServiceTest {
 
     when(jwtService.createJwtToken(any())).thenReturn(new LoginResponseDto(token, expiresIn));
     when(userService.findByEmail(any())).thenReturn(Optional.of(user));
-    when(passwordEncoder.matches(any(), any())).thenReturn(true);
+    when(bCryptPasswordEncoder.matches(any(), any())).thenReturn(true);
 
     assertThrows(EmailNotVerifiedException.class, () -> loginService.login(new LoginRequestDto(email, password)));
   }

--- a/src/test/java/br/com/conectabyte/profissu/services/RoleServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/RoleServiceTest.java
@@ -1,0 +1,38 @@
+package br.com.conectabyte.profissu.services;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import br.com.conectabyte.profissu.enums.RoleEnum;
+import br.com.conectabyte.profissu.repositories.RoleRepository;
+import br.com.conectabyte.profissu.utils.RoleUtils;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class RoleServiceTest {
+  @Mock
+  private RoleRepository roleRepository;
+
+  @InjectMocks
+  private RoleService roleService;
+
+  @Test
+  void shouldFindRoleByNameSuccessfully() {
+    final var roleName = RoleEnum.USER.name();
+    when(roleRepository.findByName(any())).thenReturn(Optional.of(RoleUtils.create(roleName)));
+
+    final var role = roleService.findByName(roleName);
+
+    assertTrue(role.isPresent());
+    assertTrue(role.get().getName().equals("USER"));
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/services/UserServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/UserServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
-import br.com.conectabyte.profissu.dtos.PasswordRecoveryRequestDto;
+import br.com.conectabyte.profissu.dtos.EmailValueRequestDto;
 import br.com.conectabyte.profissu.dtos.ResetPasswordRequestDto;
 import br.com.conectabyte.profissu.entities.Token;
 import br.com.conectabyte.profissu.enums.ContactTypeEnum;
@@ -101,7 +101,7 @@ public class UserServiceTest {
     when(this.tokenService.save(any())).thenReturn(new Token());
     doNothing().when(this.emailService).sendPasswordRecoveryEmail(any(), any());
 
-    this.userService.recoverPassword(new PasswordRecoveryRequestDto(email));
+    this.userService.recoverPassword(new EmailValueRequestDto(email));
 
     verify(this.tokenService, times(1)).deleteByUser(any());
     verify(this.tokenService, times(1)).save(any());
@@ -117,7 +117,7 @@ public class UserServiceTest {
     when(this.tokenService.save(any())).thenReturn(new Token());
     doThrow(new MessagingException()).when(this.emailService).sendPasswordRecoveryEmail(any(), any());
 
-    this.userService.recoverPassword(new PasswordRecoveryRequestDto(email));
+    this.userService.recoverPassword(new EmailValueRequestDto(email));
 
     verify(this.tokenService, times(1)).deleteByUser(any());
     verify(this.tokenService, times(1)).save(any());
@@ -129,7 +129,7 @@ public class UserServiceTest {
     final var email = "test@conectabyte.com.br";
 
     when(this.userRepository.findByEmail(any())).thenReturn(Optional.empty());
-    this.userService.recoverPassword(new PasswordRecoveryRequestDto(email));
+    this.userService.recoverPassword(new EmailValueRequestDto(email));
 
     verify(this.tokenService, times(0)).deleteByUser(any());
     verify(this.tokenService, times(0)).save(any());

--- a/src/test/java/br/com/conectabyte/profissu/services/UserServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/UserServiceTest.java
@@ -87,7 +87,7 @@ public class UserServiceTest {
     user.setAddresses(List.of(AddressUtils.create(user)));
     when(this.userRepository.save(any())).thenReturn(user);
 
-    final var savedUser = this.userService.save(userMapper.userToUserRequestDto(user));
+    final var savedUser = this.userService.register(userMapper.userToUserRequestDto(user));
 
     assertTrue(savedUser != null);
   }

--- a/src/test/java/br/com/conectabyte/profissu/utils/RoleUtils.java
+++ b/src/test/java/br/com/conectabyte/profissu/utils/RoleUtils.java
@@ -3,11 +3,11 @@ package br.com.conectabyte.profissu.utils;
 import br.com.conectabyte.profissu.entities.Role;
 
 public class RoleUtils {
-  public static Role createRole() {
-    return createRole("TEST");
+  public static Role create() {
+    return create("TEST");
   }
 
-  public static Role createRole(String name) {
+  public static Role create(String name) {
     var role = new Role();
 
     role.setName(name);


### PR DESCRIPTION
### Description
Implemented email confirmation functionalities, enhancing the user registration flow with confirmation and re-sending capabilities.

### Main Changes
- **Email confirmation on registration:** Added the functionality to send a confirmation email upon user registration, containing a unique confirmation code.
- **Resend confirmation email:** Implemented the option for users to request a resend of the confirmation email if they did not receive the first one.
- **Account confirmation endpoint:** Created the `POST /sign-up-confirmation` endpoint, allowing users to confirm their account using the code received by email.
- **API documentation:** Documented the new endpoints, including request and response structures, to ensure clear communication and integration.
- **Unit tests:** Added comprehensive unit tests to verify the functionality of the email confirmation flow, including scenarios for resending the email and confirming with valid or invalid codes.