### PR TITLE
Create endpoint for deleting profile

### DIFF
--- a/src/main/java/br/com/conectabyte/profissu/config/SecurityConfig.java
+++ b/src/main/java/br/com/conectabyte/profissu/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -24,6 +25,7 @@ import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
   @Value("${profissu.jwt.public-key-location}")
   private RSAPublicKey publicKey;

--- a/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
@@ -1,6 +1,7 @@
 package br.com.conectabyte.profissu.controllers;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,8 +36,10 @@ public class UserController {
 
   @Operation(summary = "Delete user profile by ID", description = "Soft deletes the user profile by the given ID.", responses = {
       @ApiResponse(responseCode = "202", description = "Accept delete request", content = @Content(mediaType = "application/json")),
-      @ApiResponse(responseCode = "401", description = "Invalid or missing credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
+      @ApiResponse(responseCode = "401", description = "Invalid or missing credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
   })
+  @PreAuthorize("@securityService.isOwner(#id) || @securityService.isAdmin()")
   @DeleteMapping("/{id}")
   public ResponseEntity<Void> deleteById(@PathVariable Long id) {
     this.userService.deleteById(id);

--- a/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
@@ -33,6 +33,10 @@ public class UserController {
     return ResponseEntity.ok().body(this.userService.findById(id));
   }
 
+  @Operation(summary = "Delete user profile by ID", description = "Soft deletes the user profile by the given ID.", responses = {
+      @ApiResponse(responseCode = "202", description = "Accept delete request", content = @Content(mediaType = "application/json")),
+      @ApiResponse(responseCode = "401", description = "Invalid or missing credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
+  })
   @DeleteMapping("/{id}")
   public ResponseEntity<Void> deleteById(@PathVariable Long id) {
     this.userService.deleteById(id);

--- a/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
@@ -1,6 +1,7 @@
 package br.com.conectabyte.profissu.controllers;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,5 +31,11 @@ public class UserController {
   @GetMapping("/{id}")
   public ResponseEntity<UserResponseDto> findById(@PathVariable Long id) {
     return ResponseEntity.ok().body(this.userService.findById(id));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteById(@PathVariable Long id) {
+    this.userService.deleteById(id);
+    return ResponseEntity.accepted().build();
   }
 }

--- a/src/main/java/br/com/conectabyte/profissu/handlers/RestExceptionHandler.java
+++ b/src/main/java/br/com/conectabyte/profissu/handlers/RestExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -43,11 +44,14 @@ public class RestExceptionHandler {
   @ExceptionHandler({ NoResourceFoundException.class, ResourceNotFoundException.class })
   public ResponseEntity<ExceptionDto> notFoundExceptionHandler(Exception e) {
     log.error("Error: {}", e.getMessage());
-    if (e instanceof ResourceNotFoundException) {
-      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ExceptionDto(e.getMessage(), null));
-    }
+    final var messageError = e instanceof ResourceNotFoundException ? e.getMessage() : "Resource not found";
 
-    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ExceptionDto("Resource not found", null));
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ExceptionDto(messageError, null));
+  }
+
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ExceptionDto> handleAccessDeniedException(AccessDeniedException ex) {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ExceptionDto("Access denied.", null));
   }
 
   @ExceptionHandler(Exception.class)

--- a/src/main/java/br/com/conectabyte/profissu/services/JwtService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/JwtService.java
@@ -1,9 +1,13 @@
 package br.com.conectabyte.profissu.services;
 
 import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
@@ -23,20 +27,32 @@ public class JwtService {
   private final JwtEncoder jwtEncoder;
 
   public LoginResponseDto createJwtToken(User user) {
-    var now = Instant.now();
-    var expiresIn = 300L;
-    var scopes = user.getRoles().stream()
+    final var now = Instant.now();
+    final var expiresIn = 300L;
+    final var scopes = user.getRoles().stream()
         .map(Role::getName)
         .collect(Collectors.joining(" "));
-    var claims = JwtClaimsSet.builder()
+    final var claims = JwtClaimsSet.builder()
         .issuer(issuer)
         .subject(user.getId().toString())
         .issuedAt(now)
         .expiresAt(now.plusSeconds(expiresIn))
         .claim("ROLE", scopes)
         .build();
-    var jwtValue = jwtEncoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();
+    final var jwtValue = jwtEncoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();
 
     return new LoginResponseDto(jwtValue, expiresIn);
+  }
+
+  public Optional<Map<String, Object>> getClaims() {
+    final var authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (authentication != null && authentication.getPrincipal() instanceof Jwt) {
+      final var jwt = (Jwt) authentication.getPrincipal();
+
+      return Optional.of(jwt.getClaims());
+    }
+
+    return Optional.empty();
   }
 }

--- a/src/main/java/br/com/conectabyte/profissu/services/SecurityService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/SecurityService.java
@@ -1,0 +1,25 @@
+package br.com.conectabyte.profissu.services;
+
+import org.springframework.stereotype.Service;
+
+import br.com.conectabyte.profissu.enums.RoleEnum;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SecurityService {
+  private final JwtService jwtService;
+
+  public boolean isOwner(Long userId) {
+    return this.jwtService.getClaims()
+        .map(claims -> Long.valueOf(claims.get("sub").toString()).equals(userId))
+        .orElse(false);
+  }
+
+  public boolean isAdmin() {
+    return this.jwtService.getClaims()
+        .map(claims -> String.valueOf(claims.get("ROLE")).contains(RoleEnum.ADMIN.name()))
+        .orElse(false);
+  }
+
+}

--- a/src/main/java/br/com/conectabyte/profissu/services/UserService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/UserService.java
@@ -210,4 +210,14 @@ public class UserService {
 
     return userMapper.userToUserResponseDto(user);
   }
+
+  @Async
+  public void deleteById(Long id) {
+    final var optionalUser = this.userRepository.findById(id);
+
+    optionalUser.ifPresent(user -> {
+      user.setDeletedAt(LocalDateTime.now());
+      userRepository.save(user);
+    });
+  }
 }

--- a/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
@@ -12,17 +12,17 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import br.com.conectabyte.profissu.config.SecurityConfig;
 import br.com.conectabyte.profissu.dtos.request.EmailValueRequestDto;
 import br.com.conectabyte.profissu.dtos.request.LoginRequestDto;
 import br.com.conectabyte.profissu.dtos.request.ResetPasswordRequestDto;
@@ -40,9 +40,8 @@ import br.com.conectabyte.profissu.utils.AddressUtils;
 import br.com.conectabyte.profissu.utils.ContactUtils;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@ActiveProfiles("test")
+@WebMvcTest(AuthController.class)
+@Import(SecurityConfig.class)
 public class AuthControllerTest {
   private final UserMapper userMapper = UserMapper.INSTANCE;
 

--- a/src/test/java/br/com/conectabyte/profissu/controllers/UserControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/UserControllerTest.java
@@ -1,8 +1,10 @@
 package br.com.conectabyte.profissu.controllers;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -11,17 +13,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import br.com.conectabyte.profissu.config.SecurityConfig;
 import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
 import br.com.conectabyte.profissu.mappers.UserMapper;
 import br.com.conectabyte.profissu.services.UserService;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
 @WebMvcTest(UserController.class)
-@ActiveProfiles("test")
+@Import(SecurityConfig.class)
 public class UserControllerTest {
   private final UserMapper userMapper = UserMapper.INSTANCE;
 
@@ -50,5 +53,14 @@ public class UserControllerTest {
 
     mockMvc.perform(get("/users/1"))
         .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser
+  void shouldAcceptDeletionRequest() throws Exception {
+    doNothing().when(userService).deleteById(any());
+
+    mockMvc.perform(delete("/users/1"))
+        .andExpect(status().isAccepted());
   }
 }

--- a/src/test/java/br/com/conectabyte/profissu/repositories/UserRepositoryTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/repositories/UserRepositoryTest.java
@@ -2,6 +2,7 @@ package br.com.conectabyte.profissu.repositories;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -66,6 +67,91 @@ public class UserRepositoryTest {
     user.setContacts(List.of(contact));
     userRepository.save(user);
     final var optionalUser = userRepository.findByEmail(email);
+
+    assertTrue(optionalUser.isEmpty());
+  }
+
+  @Test
+  void shouldReturnUserWhenHaveAnUserWithInformedId() {
+    final var user = UserUtils.create();
+    user.setContacts(List.of(ContactUtils.create(user)));
+    final var savedUser = userRepository.save(user);
+    final var optionalUser = userRepository.findById(savedUser.getId());
+
+    assertTrue(optionalUser.isPresent());
+  }
+
+  @Test
+  void shouldNotFindUserWhenThenIsDeleted() {
+    final var user = UserUtils.create();
+    user.setDeletedAt(LocalDateTime.now());
+    user.setContacts(List.of(ContactUtils.create(user)));
+    final var savedUser = userRepository.save(user);
+    final var optionalUser = userRepository.findById(savedUser.getId());
+
+    assertTrue(optionalUser.isEmpty());
+  }
+
+  @Test
+  void shouldNotFindUserIfIdlDoesNotExist() {
+    final var optionalUser = userRepository.findById(0L);
+
+    assertTrue(optionalUser.isEmpty());
+  }
+
+  @Test
+  void shouldNotFindUserByIdWhenUserNotHaveDefinedContact() {
+    final var user = UserUtils.create();
+    final var savedUser = userRepository.save(user);
+    final var optionalUser = userRepository.findById(savedUser.getId());
+
+    assertTrue(optionalUser.isEmpty());
+  }
+
+  @Test
+  void shouldNotFindUserByIdWhenUserNotHaveEmailContact() {
+    final var user = UserUtils.create();
+    final var contact = ContactUtils.create(user);
+    contact.setType(ContactTypeEnum.PHONE);
+    user.setContacts(List.of(contact));
+    final var savedUser = userRepository.save(user);
+    final var optionalUser = userRepository.findById(savedUser.getId());
+
+    assertTrue(optionalUser.isEmpty());
+  }
+
+  @Test
+  void shouldNotFindUserByIdWhenUserNotHaveStandarnContact() {
+    final var user = UserUtils.create();
+    final var contact = ContactUtils.create(user);
+    contact.setStandard(false);
+    user.setContacts(List.of(contact));
+    final var savedUser = userRepository.save(user);
+    final var optionalUser = userRepository.findById(savedUser.getId());
+
+    assertTrue(optionalUser.isEmpty());
+  }
+
+  @Test
+  void shouldNotFindUserByIdWhenUserNotHaveVerifiedContact() {
+    final var user = UserUtils.create();
+    final var contact = ContactUtils.create(user);
+    contact.setVerificationCompletedAt(null);
+    user.setContacts(List.of(contact));
+    final var savedUser = userRepository.save(user);
+    final var optionalUser = userRepository.findById(savedUser.getId());
+
+    assertTrue(optionalUser.isEmpty());
+  }
+
+  @Test
+  void shouldNotFindUserByIdWhenUserContactWasDeleted() {
+    final var user = UserUtils.create();
+    final var contact = ContactUtils.create(user);
+    contact.setDeletedAt(LocalDateTime.now());
+    user.setContacts(List.of(contact));
+    final var savedUser = userRepository.save(user);
+    final var optionalUser = userRepository.findById(savedUser.getId());
 
     assertTrue(optionalUser.isEmpty());
   }

--- a/src/test/java/br/com/conectabyte/profissu/services/JwtServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/JwtServiceTest.java
@@ -8,27 +8,30 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
-import org.springframework.test.context.ActiveProfiles;
 
 import br.com.conectabyte.profissu.utils.RoleUtils;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
-@SpringBootTest
-@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
 public class JwtServiceTest {
-  @MockBean
+  @Mock
   private JwtEncoder jwtEncoder;
 
-  @Autowired
+  @InjectMocks
   private JwtService jwtService;
 
   @Test
-  void shouldReturnTokenWhenSuccess() {
+  void shouldReturnTokenWhenSuccess() throws Exception {
+    var issuerField = JwtService.class.getDeclaredField("issuer");
+    issuerField.setAccessible(true);
+    issuerField.set(jwtService, "profissu");
+
     final var user = UserUtils.create();
     final var map = Map.of("key", new Object());
 

--- a/src/test/java/br/com/conectabyte/profissu/services/JwtServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/JwtServiceTest.java
@@ -1,19 +1,29 @@
 package br.com.conectabyte.profissu.services;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 
 import br.com.conectabyte.profissu.utils.RoleUtils;
 import br.com.conectabyte.profissu.utils.UserUtils;
@@ -26,19 +36,98 @@ public class JwtServiceTest {
   @InjectMocks
   private JwtService jwtService;
 
-  @Test
-  void shouldReturnTokenWhenSuccess() throws Exception {
+  @BeforeEach
+  void setUp() throws Exception {
     var issuerField = JwtService.class.getDeclaredField("issuer");
     issuerField.setAccessible(true);
     issuerField.set(jwtService, "profissu");
+  }
 
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void shouldReturnTokenWhenSuccess() {
     final var user = UserUtils.create();
+    final var now = Instant.now();
     final var map = Map.of("key", new Object());
 
-    user.setRoles((Set.of(RoleUtils.create())));
+    user.setRoles(Set.of(RoleUtils.create()));
     user.setId(1L);
-    when(jwtEncoder.encode(any())).thenReturn(new Jwt("TOKEN", Instant.now(), Instant.now(), map, map));
 
-    jwtService.createJwtToken(user);
+    when(jwtEncoder.encode(any())).thenReturn(new Jwt("TOKEN", now, now.plusSeconds(1), map, map));
+
+    final var response = jwtService.createJwtToken(user);
+
+    assertEquals("TOKEN", response.accessToken());
+    assertEquals(300L, response.expiresIn());
+
+    verify(jwtEncoder).encode(any(JwtEncoderParameters.class));
+  }
+
+  @Test
+  void shouldContainCorrectClaims() {
+    final var user = UserUtils.create();
+    final var now = Instant.now();
+    final var map = Map.of("key", new Object());
+
+    user.setRoles(Set.of(RoleUtils.create()));
+    user.setId(1L);
+
+    when(jwtEncoder.encode(any())).thenReturn(new Jwt("FAKE_TOKEN", now, now.plusSeconds(1), map, map));
+
+    final var response = jwtService.createJwtToken(user);
+
+    assertEquals("FAKE_TOKEN", response.accessToken());
+    assertEquals(300L, response.expiresIn());
+  }
+
+  @Test
+  void shouldReturnClaimsWhenJwtIsPresent() {
+    final Map<String, Object> claims = Map.of();
+    final var jwt = mock(Jwt.class);
+    final var authentication = mock(Authentication.class);
+    final var securityContext = mock(SecurityContext.class);
+
+    when(jwt.getClaims()).thenReturn(claims);
+    when(authentication.getPrincipal()).thenReturn(jwt);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+
+    SecurityContextHolder.setContext(securityContext);
+
+    final var result = jwtService.getClaims();
+
+    assertTrue(result.isPresent());
+    assertEquals(claims, result.get());
+  }
+
+  @Test
+  void shouldReturnEmptyWhenAuthenticationIsNull() {
+    final var securityContext = mock(SecurityContext.class);
+
+    when(securityContext.getAuthentication()).thenReturn(null);
+
+    SecurityContextHolder.setContext(securityContext);
+
+    final var result = jwtService.getClaims();
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void shouldReturnEmptyWhenPrincipalIsNotJwt() {
+    final var authentication = mock(Authentication.class);
+    final var securityContext = mock(SecurityContext.class);
+
+    when(authentication.getPrincipal()).thenReturn("Not a Jwt");
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+
+    SecurityContextHolder.setContext(securityContext);
+
+    final var result = jwtService.getClaims();
+
+    assertTrue(result.isEmpty());
   }
 }

--- a/src/test/java/br/com/conectabyte/profissu/services/LoginServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/LoginServiceTest.java
@@ -9,12 +9,12 @@ import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
 
 import br.com.conectabyte.profissu.dtos.request.LoginRequestDto;
 import br.com.conectabyte.profissu.dtos.response.LoginResponseDto;
@@ -22,19 +22,18 @@ import br.com.conectabyte.profissu.exceptions.EmailNotVerifiedException;
 import br.com.conectabyte.profissu.utils.ContactUtils;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
-@SpringBootTest
-@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
 public class LoginServiceTest {
-  @MockBean
+  @Mock
   private JwtService jwtService;
 
-  @MockBean
+  @Mock
   private UserService userService;
 
-  @MockBean
+  @Mock
   private BCryptPasswordEncoder bCryptPasswordEncoder;
 
-  @Autowired
+  @InjectMocks
   private LoginService loginService;
 
   @Test
@@ -59,36 +58,26 @@ public class LoginServiceTest {
 
   @Test
   void shouldThrowExceptionWhenUserNotFoundWithEmail() {
-    final var token = "token_test";
-    final var expiresIn = 1L;
     final var email = "test@conectabyte.com.br";
     final var password = "$2y$10$D.E2J7CeUXU4G3QUqYJGN.jdo75P7iHVApCRkF.DRmGI8tQy3Tn.G";
 
-    when(jwtService.createJwtToken(any())).thenReturn(new LoginResponseDto(token, expiresIn));
     when(userService.findByEmail(any())).thenReturn(Optional.empty());
-    when(bCryptPasswordEncoder.matches(any(), any())).thenReturn(true);
 
     assertThrows(BadCredentialsException.class, () -> loginService.login(new LoginRequestDto(email, password)));
   }
 
   @Test
   void shouldThrowExceptionWhenPasswordIsInvalid() {
-    final var token = "token_test";
-    final var expiresIn = 1L;
     final var email = "test@conectabyte.com.br";
     final var password = "$2y$10$D.E2J7CeUXU4G3QUqYJGN.jdo75P7iHVApCRkF.DRmGI8tQy3Tn.G";
 
-    when(jwtService.createJwtToken(any())).thenReturn(new LoginResponseDto(token, expiresIn));
     when(userService.findByEmail(any())).thenReturn(Optional.of(UserUtils.create()));
-    when(bCryptPasswordEncoder.matches(any(), any())).thenReturn(false);
 
     assertThrows(BadCredentialsException.class, () -> loginService.login(new LoginRequestDto(email, password)));
   }
 
   @Test
   void shouldThrowExceptionWhenEmailIsUnverified() {
-    final var token = "token_test";
-    final var expiresIn = 1L;
     final var email = "test@conectabyte.com.br";
     final var password = "$2y$10$D.E2J7CeUXU4G3QUqYJGN.jdo75P7iHVApCRkF.DRmGI8tQy3Tn.G";
     final var user = UserUtils.create();
@@ -96,7 +85,6 @@ public class LoginServiceTest {
     contact.setVerificationCompletedAt(null);
     user.setContacts(List.of(contact));
 
-    when(jwtService.createJwtToken(any())).thenReturn(new LoginResponseDto(token, expiresIn));
     when(userService.findByEmail(any())).thenReturn(Optional.of(user));
     when(bCryptPasswordEncoder.matches(any(), any())).thenReturn(true);
 

--- a/src/test/java/br/com/conectabyte/profissu/services/RoleServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/RoleServiceTest.java
@@ -7,17 +7,16 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import br.com.conectabyte.profissu.enums.RoleEnum;
 import br.com.conectabyte.profissu.repositories.RoleRepository;
 import br.com.conectabyte.profissu.utils.RoleUtils;
 
-@SpringBootTest
-@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
 public class RoleServiceTest {
   @Mock
   private RoleRepository roleRepository;

--- a/src/test/java/br/com/conectabyte/profissu/services/SecurityServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/SecurityServiceTest.java
@@ -1,0 +1,59 @@
+package br.com.conectabyte.profissu.services;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class SecurityServiceTest {
+  @Mock
+  private JwtService jwtService;
+
+  @InjectMocks
+  private SecurityService securityService;
+
+  @Test
+  void shouldReturnTrueWhenInformetedIDIsSameThenToken() {
+    when(jwtService.getClaims()).thenReturn(Optional.of(Map.of("sub", "1")));
+
+    final var isOwner = securityService.isOwner(1L);
+
+    assertTrue(isOwner);
+  }
+
+  @Test
+  void shouldReturnFalseWhenTheInformetedIDNNotIsSameThenToken() {
+    when(jwtService.getClaims()).thenReturn(Optional.of(Map.of("sub", "0")));
+
+    final var isOwner = securityService.isOwner(1L);
+
+    assertFalse(isOwner);
+  }
+
+  @Test
+  void shouldReturnTrueWhenUserHaveAdminRole() {
+    when(jwtService.getClaims()).thenReturn(Optional.of(Map.of("ROLE", "ADMIN")));
+
+    final var isAdmin = securityService.isAdmin();
+
+    assertTrue(isAdmin);
+  }
+
+  @Test
+  void shouldReturnFalseWhenUserNotHaveAdminRole() {
+    when(jwtService.getClaims()).thenReturn(Optional.of(Map.of("ROLE", "USER")));
+
+    final var isAdmin = securityService.isAdmin();
+
+    assertFalse(isAdmin);
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/services/TokenServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/TokenServiceTest.java
@@ -8,20 +8,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
 
 import br.com.conectabyte.profissu.entities.Token;
 import br.com.conectabyte.profissu.entities.User;
 import br.com.conectabyte.profissu.repositories.TokenRepository;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
-@SpringBootTest
-@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
 class TokenServiceTest {
 
   @Mock

--- a/src/test/java/br/com/conectabyte/profissu/services/UserServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/UserServiceTest.java
@@ -22,7 +22,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
 
 import br.com.conectabyte.profissu.dtos.request.EmailValueRequestDto;
 import br.com.conectabyte.profissu.dtos.request.ResetPasswordRequestDto;
@@ -38,7 +37,6 @@ import br.com.conectabyte.profissu.utils.UserUtils;
 import jakarta.mail.MessagingException;
 
 @ExtendWith(MockitoExtension.class)
-@ActiveProfiles("test")
 public class UserServiceTest {
   private final UserMapper userMapper = UserMapper.INSTANCE;
 
@@ -326,5 +324,15 @@ public class UserServiceTest {
 
     final var exceptionMessage = assertThrows(ResourceNotFoundException.class, () -> userService.findById(any()));
     assertEquals("User not found.", exceptionMessage.getMessage());
+  }
+
+  @Test
+  void shouldMarkUserAsDeleted() {
+    final var user = UserUtils.create();
+    when(userRepository.findById(any())).thenReturn(Optional.of(user));
+
+    userService.deleteById(any());
+
+    assertNotNull(user.getDeletedAt());;
   }
 }


### PR DESCRIPTION
### Description
Created an endpoint for deleting user profiles, allowing admins or profile owners to delete profiles.

### Main Changes
- **Profile deletion endpoint**: Implemented the `DELETE /users/{id}` endpoint, which allows users to delete their profile if they are the owner or an admin.
- **User permissions validation**: Added a check to ensure that only the owner or an admin can delete a profile, using a service method for validation.
- **API documentation**: Documented the new endpoint using Swagger, including request and response structures.
- **Unit tests**: Added unit tests to validate the profile deletion logic, ensuring that only authorized users (owners or admins) can delete profiles.