### PR TITLE
Create endpoint for updating password

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Code of Conduct
+
+## Our Commitment
+
+In order to foster an open and welcoming environment for all, we, the participants and contributors of this project, commit to treating everyone with respect and empathy. We aim to ensure that everyone feels safe and welcome, regardless of their background, experience, or perspective.
+
+## Expected Behavior
+
+- **Be respectful:** Treat others with courtesy and respect. Respect for diverse opinions and experiences is key to creating a healthy environment.
+- **Constructive communication:** Keep the tone friendly and avoid destructive criticism. Fostering productive discussions helps the project grow.
+- **Be inclusive:** Strive to include everyone in discussions and activities. Contributions from diverse perspectives enrich the project.
+- **Responsible behavior:** Adhere to local laws and norms, especially regarding privacy and intellectual property rights.
+
+## Unacceptable Behavior
+
+- **Discrimination and harassment:** Any form of discrimination or harassment, including, but not limited to, discrimination based on age, disability, ethnicity, gender, gender identity, nationality, race, religion, or sexual orientation.
+- **Offensive language:** Use of aggressive, hostile, or disrespectful language or behavior.
+- **Aggressive or intimidating behavior:** Any form of intimidation, stalking, bullying, or harassment, both online and in person.
+- **Trolling and spam:** Irrelevant posts, spam links, or any form of content unrelated to the project.
+
+## Consequences of Unacceptable Behavior
+
+Participants exhibiting unacceptable behavior may be asked to leave the project or community. Depending on the severity of the violation, more severe sanctions may be applied, including a permanent ban from participation.
+
+## How to Report Unacceptable Behavior
+
+If you are the victim or a witness to unacceptable behavior, we encourage you to contact us directly at [contact email] or through our reporting system. All reports will be handled confidentially and with the utmost seriousness.
+
+## License
+
+This Code of Conduct is based on the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to PROFISU
+
+Thank you for considering contributing to PROFISU! We welcome contributions to improve the project, whether it's fixing bugs, adding new features, improving documentation, or helping with other tasks.
+
+## How to Get Started
+
+1. **Fork the Repository**  
+   Start by forking the repository to your own GitHub account.
+
+2. **Clone the Repository**  
+   Clone the forked repository to your local machine:
+   ```bash
+   git clone https://github.com/VitorSantosCruz/profissu.git
+   ```
+
+3. **Install Dependencies**  
+   Make sure you have Java 21 and Docker installed on your machine. Install the necessary dependencies with Maven:
+   ```bash
+   mvn install
+   ```
+
+4. **Create a New Branch**  
+   Create a new branch for the feature or bug fix you're working on:
+   ```bash
+   git checkout -b your-feature-branch
+   ```
+
+5. **Make Your Changes**  
+   Implement your changes, keeping the code clean and following the project's coding style.
+
+6. **Run Tests**  
+   Before submitting your contribution, ensure all tests pass:
+   ```bash
+   mvn test
+   ```
+
+7. **Commit Your Changes**  
+   Commit your changes with a clear and concise message:
+   ```bash
+   git commit -am 'Add your changes'
+   ```
+
+8. **Push Your Changes**  
+   Push your changes to your forked repository:
+   ```bash
+   git push origin your-feature-branch
+   ```
+
+9. **Submit a Pull Request**  
+   Go to the repository on GitHub and open a pull request (PR) to the main branch of the project. Make sure to include a description of what your PR does and why the changes are needed.
+
+## Code of Conduct
+
+By participating in this project, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md). We expect everyone to contribute respectfully and to create an inclusive and collaborative environment.
+
+## Reporting Issues
+
+If you encounter any bugs or issues while using PROFISU, please report them by creating an issue on GitHub. Be sure to include as much detail as possible, including steps to reproduce the issue, error messages, and the environment you are using.
+
+## License
+
+By contributing to PROFISU, you agree that your contributions will be licensed under the project's [MIT License](LICENSE).
+
+---
+
+Thank you for helping make PROFISU better 💜!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 PROFISU
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -43,28 +43,23 @@ Profissu is built with modern and robust technologies, ensuring high performance
 
 ## **System Architecture**
 
-Profissu follows a well-defined layered architecture, promoting maintainability, scalability, and testability:
+Profissu follows a layered architecture, promoting maintainability, scalability, and testability:
 
 * **Presentation Layer (Controllers):** Handles HTTP requests, validates inputs, and interacts with the Application Layer.
 * **Application Layer (Services):** Contains business logic, orchestrating interactions between components.
 * **Persistence Layer (Repositories):** Abstracts database access, simplifying data persistence operations.
 * **Domain Layer (Domain Model):** Defines core entities and their relationships, representing the application's business concepts.
 
-## **Component-Based Organization**
-
-We adopt a component-based organization to structure the project effectively, dividing it into independent modules, each responsible for a specific system functionality. This approach improves maintainability, code reusability, and application scalability.
-
 ## **Development Practices**
 
 * **Agile Development:** We follow agile methodologies, prioritizing iterative development, frequent feedback, and continuous improvement.
-* **Test-Driven Development (TDD):** We write tests before code to ensure code quality and reduce the risk of bugs.  
 * **Continuous Integration/Continuous Deployment (CI/CD):** We aim to implement CI/CD pipelines to automate the build, test, and deployment processes.
 
 ## **How to Run the Application**
 
 1. **Clone the Repository:**
    ```bash
-   git clone [https://github.com/VitorSantosCruz/profissu.git](https://github.com/VitorSantosCruz/profissu.git)
+   git clone https://github.com/VitorSantosCruz/profissu.git
    ```
 
 2. **Navigate to the Project Directory:**

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -46,7 +46,7 @@ services:
       retries: 5
 
   app:
-    build: .
+    image: maven:3.9.9-amazoncorretto-21-alpine
     container_name: profissu
     environment:
       - "SPRING_PROFILE=dev"
@@ -65,7 +65,10 @@ services:
     ports:
       - "8081:8081"
     volumes:
+      - .:/app
       - maven_cache:/root/.m2
+    working_dir: /app
+    command: ["mvn", "spring-boot:run"]
     depends_on:
       mysql:
         condition: service_healthy

--- a/src/main/java/br/com/conectabyte/profissu/config/SwaggerConfig.java
+++ b/src/main/java/br/com/conectabyte/profissu/config/SwaggerConfig.java
@@ -3,7 +3,10 @@ package br.com.conectabyte.profissu.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 
@@ -12,6 +15,16 @@ public class SwaggerConfig {
   @Bean
   public OpenAPI customOpenAPI() {
     return new OpenAPI()
+        .info(new Info()
+            .title("PROFISU API")
+            .description("API para conectar profissionais e clientes.")
+            .version("0.0.1")
+            .license(new License()
+                .name("MIT License")
+                .url("https://opensource.org/licenses/MIT")))
+        .externalDocs(new ExternalDocumentation()
+            .description("Repositório no GitHub")
+            .url("https://github.com/VitorSantosCruz/profissu"))
         .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
         .components(new io.swagger.v3.oas.models.Components()
             .addSecuritySchemes("BearerAuth",

--- a/src/main/java/br/com/conectabyte/profissu/controllers/AuthController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/AuthController.java
@@ -32,62 +32,61 @@ public class AuthController {
   private final LoginService loginService;
   private final UserService userService;
 
-  @Operation(summary = "Authenticate user", description = "Validates user credentials and returns authentication details.", responses = {
+  @Operation(summary = "Authenticate user", description = "Validates the provided user credentials and returns authentication details, including access tokens.", responses = {
       @ApiResponse(responseCode = "200", description = "User successfully authenticated", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LoginResponseDto.class))),
-      @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "400", description = "Invalid request format or missing required fields", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
       @ApiResponse(responseCode = "401", description = "Invalid credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
   })
   @PostMapping("/login")
   public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto credentials) {
-    return ResponseEntity.status(HttpStatus.CREATED).body(loginService.login(credentials));
+    return ResponseEntity.ok(loginService.login(credentials));
   }
 
-  @Operation(summary = "Register user", description = "Validates user data save and returns saved user data.", responses = {
+  @Operation(summary = "Register new user", description = "Validates and saves the provided user data, creating a new user account.", responses = {
       @ApiResponse(responseCode = "201", description = "User successfully created", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserResponseDto.class))),
-      @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
+      @ApiResponse(responseCode = "400", description = "Invalid request format or missing required fields", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
   })
   @PostMapping("/register")
   public ResponseEntity<UserResponseDto> register(@Valid @RequestBody UserRequestDto user) {
-    return ResponseEntity.status(HttpStatus.CREATED).body(this.userService.register(user));
+    return ResponseEntity.status(HttpStatus.CREATED).body(userService.register(user));
   }
 
-  @Operation(summary = "Sign-up confirmation", description = "Receives sign-up confirmation requests", responses = {
-      @ApiResponse(responseCode = "200", description = "Sign-up was successfully confirmated.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageValueResponseDto.class))),
-      @ApiResponse(responseCode = "400", description = "Sign-up was not confirmated.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageValueResponseDto.class)))
+  @Operation(summary = "Confirm user sign-up", description = "Validates and confirms a user's sign-up request.", responses = {
+      @ApiResponse(responseCode = "200", description = "Sign-up successfully confirmed", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageValueResponseDto.class))),
+      @ApiResponse(responseCode = "400", description = "Sign-up confirmation failed", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageValueResponseDto.class)))
   })
   @PostMapping("/sign-up-confirmation")
   public ResponseEntity<MessageValueResponseDto> signUpConfirmation(
-      @Valid @RequestBody SignUpConfirmationRequestDto signUpConfirmationRequestDto) {
-    final var response = this.userService.signUpConfirmation(signUpConfirmationRequestDto);
+      @Valid @RequestBody SignUpConfirmationRequestDto request) {
+    final var response = this.userService.signUpConfirmation(request);
     return ResponseEntity.status(response.responseCode()).body(response);
   }
 
-  @Operation(summary = "Resend sign-up confirmation", description = "Receives resend sign-up confirmation requests", responses = {
-      @ApiResponse(responseCode = "201", description = "Resend sign-up confirmation request successfully received.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Void.class)))
+  @Operation(summary = "Resend sign-up confirmation email", description = "Triggers a request to resend the sign-up confirmation email.", responses = {
+      @ApiResponse(responseCode = "202", description = "Confirmation email will be resent", content = @Content(mediaType = "application/json"))
   })
   @PostMapping("/sign-up-confirmation/resend")
-  public ResponseEntity<Void> resendSignUpConfirmation(@Valid @RequestBody EmailValueRequestDto emailValueRequestDto) {
-    this.userService.resendSignUpConfirmation(emailValueRequestDto);
+  public ResponseEntity<Void> resendSignUpConfirmation(@Valid @RequestBody EmailValueRequestDto request) {
+    this.userService.resendSignUpConfirmation(request);
     return ResponseEntity.accepted().build();
   }
 
-  @Operation(summary = "Recover password", description = "Receives password recovery requests", responses = {
-      @ApiResponse(responseCode = "201", description = "Password recovery request successfully received.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Void.class)))
+  @Operation(summary = "Request password recovery", description = "Initiates the password recovery process by sending an email with recovery instructions.", responses = {
+      @ApiResponse(responseCode = "202", description = "Password recovery email will be sent", content = @Content(mediaType = "application/json"))
   })
   @PostMapping("/password-recovery")
-  public ResponseEntity<Void> recoverPassword(@Valid @RequestBody EmailValueRequestDto emailValueRequestDto) {
-    this.userService.recoverPassword(emailValueRequestDto);
+  public ResponseEntity<Void> recoverPassword(@Valid @RequestBody EmailValueRequestDto request) {
+    this.userService.recoverPassword(request);
     return ResponseEntity.accepted().build();
   }
 
-  @Operation(summary = "Reset password", description = "Receives password reset requests", responses = {
-      @ApiResponse(responseCode = "200", description = "Password was successfully reset.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageValueResponseDto.class))),
-      @ApiResponse(responseCode = "400", description = "Password was not reset.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageValueResponseDto.class)))
+  @Operation(summary = "Reset user password", description = "Processes a password reset request and updates the user's password if valid.", responses = {
+      @ApiResponse(responseCode = "200", description = "Password successfully reset", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageValueResponseDto.class))),
+      @ApiResponse(responseCode = "400", description = "Password reset failed", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageValueResponseDto.class)))
   })
   @PostMapping("/password-reset")
-  public ResponseEntity<MessageValueResponseDto> resetPassword(
-      @Valid @RequestBody ResetPasswordRequestDto resetPasswordRequestDto) {
-    final var response = this.userService.resetPassword(resetPasswordRequestDto);
+  public ResponseEntity<MessageValueResponseDto> resetPassword(@Valid @RequestBody ResetPasswordRequestDto request) {
+    final var response = this.userService.resetPassword(request);
     return ResponseEntity.status(response.responseCode()).body(response);
   }
 }

--- a/src/main/java/br/com/conectabyte/profissu/controllers/AuthController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/AuthController.java
@@ -22,12 +22,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
+@Tag(name = "Authentication", description = "Operations related to managing authentication")
 public class AuthController {
   private final LoginService loginService;
   private final UserService userService;

--- a/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
@@ -18,12 +18,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
+@Tag(name = "Users", description = "Operations related to managing users")
 public class UserController {
   private final UserService userService;
 

--- a/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
@@ -50,6 +50,12 @@ public class UserController {
     return ResponseEntity.accepted().build();
   }
 
+  @Operation(summary = "Update user password", description = "Updates the password of a user identified by the given ID. Requires authentication.", responses = {
+      @ApiResponse(responseCode = "204", description = "Password successfully updated"),
+      @ApiResponse(responseCode = "400", description = "Malformed ID or missing parameters", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "401", description = "Invalid or missing authentication credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "403", description = "User does not have permission to update this password", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
+  })
   @PreAuthorize("@securityService.isOwner(#id) || @securityService.isAdmin()")
   @PutMapping("/{id}/password")
   public ResponseEntity<Void> updatePassword(@PathVariable Long id,

--- a/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
@@ -5,9 +5,12 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import br.com.conectabyte.profissu.dtos.request.PasswordRequestDto;
 import br.com.conectabyte.profissu.dtos.response.ExceptionDto;
 import br.com.conectabyte.profissu.dtos.response.LoginResponseDto;
 import br.com.conectabyte.profissu.dtos.response.UserResponseDto;
@@ -16,6 +19,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -44,5 +48,13 @@ public class UserController {
   public ResponseEntity<Void> deleteById(@PathVariable Long id) {
     this.userService.deleteById(id);
     return ResponseEntity.accepted().build();
+  }
+
+  @PreAuthorize("@securityService.isOwner(#id) || @securityService.isAdmin()")
+  @PutMapping("/{id}/password")
+  public ResponseEntity<Void> updatePassword(@PathVariable Long id,
+      @Valid @RequestBody PasswordRequestDto passwordRequestDto) {
+    this.userService.updatePassword(id, passwordRequestDto);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import br.com.conectabyte.profissu.dtos.request.PasswordRequestDto;
 import br.com.conectabyte.profissu.dtos.response.ExceptionDto;
-import br.com.conectabyte.profissu.dtos.response.LoginResponseDto;
 import br.com.conectabyte.profissu.dtos.response.UserResponseDto;
 import br.com.conectabyte.profissu.services.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,20 +27,23 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
   private final UserService userService;
 
-  @Operation(summary = "Get user by ID", description = "Find a user by their ID and return user data.", responses = {
-      @ApiResponse(responseCode = "200", description = "User successfully found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LoginResponseDto.class))),
-      @ApiResponse(responseCode = "404", description = "User not found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
-      @ApiResponse(responseCode = "401", description = "Invalid or missing credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
+  @Operation(summary = "Retrieve user by ID", description = "Fetches a user's details using the provided ID. Requires authentication.", responses = {
+      @ApiResponse(responseCode = "200", description = "User successfully retrieved", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserResponseDto.class))),
+      @ApiResponse(responseCode = "400", description = "Malformed ID", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "401", description = "Invalid or missing authentication credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "403", description = "User does not have permission to access this resource", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "404", description = "No user exists with the given ID", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
   })
   @GetMapping("/{id}")
   public ResponseEntity<UserResponseDto> findById(@PathVariable Long id) {
     return ResponseEntity.ok().body(this.userService.findById(id));
   }
 
-  @Operation(summary = "Delete user profile by ID", description = "Soft deletes the user profile by the given ID.", responses = {
-      @ApiResponse(responseCode = "202", description = "Accept delete request", content = @Content(mediaType = "application/json")),
-      @ApiResponse(responseCode = "401", description = "Invalid or missing credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
-      @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
+  @Operation(summary = "Soft delete user profile", description = "Marks the user profile as deleted (soft delete) using the provided ID. Requires authentication.", responses = {
+      @ApiResponse(responseCode = "202", description = "The user profile will be soft deleted"),
+      @ApiResponse(responseCode = "400", description = "Malformed ID", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "401", description = "Invalid or missing authentication credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "403", description = "User does not have permission to delete this profile", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
   })
   @PreAuthorize("@securityService.isOwner(#id) || @securityService.isAdmin()")
   @DeleteMapping("/{id}")

--- a/src/main/java/br/com/conectabyte/profissu/dtos/request/PasswordRequestDto.java
+++ b/src/main/java/br/com/conectabyte/profissu/dtos/request/PasswordRequestDto.java
@@ -1,0 +1,11 @@
+package br.com.conectabyte.profissu.dtos.request;
+
+import org.hibernate.validator.constraints.Length;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record PasswordRequestDto(
+    @NotBlank(message = "currentPassword: Cannot be null or empty") String currentPassword,
+    @NotBlank(message = "newPassword: Cannot be null or empty") @Length(min = 8, message = "newPassword: Must have at least 8 characters") @Pattern(regexp = "^(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>])[A-Za-z\\d!@#$%^&*(),.?\":{}|<>]{8,}$", message = "newPassword: Must contain at least one uppercase letter, one digit, and one special character") String newPassword) {
+}

--- a/src/main/java/br/com/conectabyte/profissu/entities/Token.java
+++ b/src/main/java/br/com/conectabyte/profissu/entities/Token.java
@@ -2,6 +2,8 @@ package br.com.conectabyte.profissu.entities;
 
 import java.time.LocalDateTime;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -36,4 +38,8 @@ public class Token {
   @OneToOne
   @JoinColumn(name = "user_id", nullable = false, unique = true)
   private User user;
+
+  public boolean isValid(String code, PasswordEncoder passwordEncoder) {
+    return passwordEncoder.matches(code, this.value);
+  }
 }

--- a/src/main/java/br/com/conectabyte/profissu/entities/User.java
+++ b/src/main/java/br/com/conectabyte/profissu/entities/User.java
@@ -6,7 +6,6 @@ import java.util.Set;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import br.com.conectabyte.profissu.dtos.request.LoginRequestDto;
 import br.com.conectabyte.profissu.enums.GenderEnum;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -80,7 +79,7 @@ public class User {
   @JoinTable(name = "users_roles", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
   private Set<Role> roles;
 
-  public boolean isValidPassword(LoginRequestDto loginRequest, PasswordEncoder passwordEncoder) {
-    return passwordEncoder.matches(loginRequest.password(), this.password);
+  public boolean isValidPassword(String password, PasswordEncoder passwordEncoder) {
+    return passwordEncoder.matches(password, this.password);
   }
 }

--- a/src/main/java/br/com/conectabyte/profissu/services/LoginService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/LoginService.java
@@ -30,7 +30,7 @@ public class LoginService {
   }
 
   private void validate(Optional<User> optionalUser, LoginRequestDto loginRequest) {
-    if (optionalUser.isEmpty() || !optionalUser.get().isValidPassword(loginRequest, passwordEncoder)) {
+    if (optionalUser.isEmpty() || !optionalUser.get().isValidPassword(loginRequest.password(), passwordEncoder)) {
       throw new BadCredentialsException("Credentials is not valid");
     }
 

--- a/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
@@ -68,7 +68,7 @@ public class AuthControllerTest {
     mockMvc.perform(post("/auth/login")
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(new LoginRequestDto(email, password))))
-        .andExpect(status().isCreated())
+        .andExpect(status().isOk())
         .andExpect(jsonPath("$.accessToken").value(token))
         .andExpect(jsonPath("$.expiresIn").value(expiresIn));
   }

--- a/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
@@ -62,7 +62,7 @@ public class AuthControllerTest {
     final var token = "token_test";
     final var expiresIn = 1L;
     final var email = "test@conectabyte.com.br";
-    final var password = "Exceptiony.E2J7CeUXU4G3QUqYJGN.jdo75P7iHVApCRkF.DRmGI8tQy3Tn.G";
+    final var password = "admin";
     when(loginService.login(any())).thenReturn(new LoginResponseDto(token, expiresIn));
 
     mockMvc.perform(post("/auth/login")
@@ -76,7 +76,7 @@ public class AuthControllerTest {
   @Test
   void shouldReturnUnauthorizedWhenCredentialsAreInvalid() throws Exception {
     final var email = "invalid@conectabyte.com.br";
-    final var password = "Exceptiony.E2J7CeUXU4G3QUqYJGN.jdo75P7iHVApCRkF.DRmGI8tQy3Tn.G";
+    final var password = "admin";
     final var errorMessage = "Credentials is not valid";
     when(loginService.login(any())).thenThrow(new BadCredentialsException(errorMessage));
 
@@ -90,7 +90,7 @@ public class AuthControllerTest {
   @Test
   void shouldReturnUnauthorizedWhenEmailIsNotVerified() throws Exception {
     final var email = "invalid@conectabyte.com.br";
-    final var password = "Exceptiony.E2J7CeUXU4G3QUqYJGN.jdo75P7iHVApCRkF.DRmGI8tQy3Tn.G";
+    final var password = "admin";
     final var errorMessage = "E-mail is not verified";
     when(loginService.login(any())).thenThrow(new EmailNotVerifiedException(errorMessage));
 
@@ -111,7 +111,7 @@ public class AuthControllerTest {
 
   @Test
   void shouldReturnBadRequestWhenEmailIsMissing() throws Exception {
-    final var password = "Exceptiony.E2J7CeUXU4G3QUqYJGN.jdo75P7iHVApCRkF.DRmGI8tQy3Tn.G";
+    final var password = "admin";
 
     mockMvc.perform(post("/auth/login")
         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/br/com/conectabyte/profissu/controllers/UserControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/UserControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -14,10 +15,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import br.com.conectabyte.profissu.config.SecurityConfig;
+import br.com.conectabyte.profissu.dtos.request.PasswordRequestDto;
 import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
 import br.com.conectabyte.profissu.mappers.UserMapper;
 import br.com.conectabyte.profissu.services.SecurityService;
@@ -37,6 +42,9 @@ public class UserControllerTest {
 
   @Autowired
   private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
 
   @Test
   @WithMockUser
@@ -87,5 +95,70 @@ public class UserControllerTest {
     mockMvc.perform(delete("/users/1"))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.message").value("Access denied."));
+  }
+
+  @Test
+  @WithMockUser()
+  void shouldUpdatePasswordWhenUserIsOwner() throws Exception {
+    final var currentPassword = "currentPassword";
+    final var newPassword = "@newPassword123";
+
+    doNothing().when(userService).updatePassword(any(), any());
+    when(securityService.isOwner(1L)).thenReturn(true);
+
+    mockMvc.perform(put("/users/1/password")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(new PasswordRequestDto(currentPassword, newPassword))))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @WithMockUser
+  void shouldUpdatePasswordWhenUserIsAdmin() throws Exception {
+    final var currentPassword = "currentPassword";
+    final var newPassword = "@newPassword123";
+
+    doNothing().when(userService).updatePassword(any(), any());
+    when(securityService.isAdmin()).thenReturn(true);
+
+    mockMvc.perform(put("/users/1/password")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(new PasswordRequestDto(currentPassword, newPassword))))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @WithMockUser
+  void shouldRejectUpdatePasswordRequestWhenUserIsNeitherAdminNorOwner() throws Exception {
+    final var currentPassword = "currentPassword";
+    final var newPassword = "@newPassword123";
+
+    mockMvc.perform(put("/users/1/password")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(new PasswordRequestDto(currentPassword, newPassword))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser
+  void shouldRejectUpdatePasswordRequestWhenCurrentPasswordIsNotValid() throws Exception {
+    final var newPassword = "newPassword";
+
+    mockMvc.perform(put("/users/1/password")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(new PasswordRequestDto(null, newPassword))))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser
+  void shouldRejectUpdatePasswordRequestWhenNewPasswordIsNotValid() throws Exception {
+    final var currentPassword = "currentPassword";
+    final var newPassword = "newPassword";
+
+    mockMvc.perform(put("/users/1/password")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(new PasswordRequestDto(currentPassword, newPassword))))
+        .andExpect(status().isBadRequest());
   }
 }


### PR DESCRIPTION
### Description
Created an endpoint for updating user passwords, allowing admins or profile owners to change passwords securely.

### Main Changes
- **Password update endpoint:** Implemented the `PUT /users/{id}/password` endpoint, allowing users to update their password if they are the owner or an admin.
- **Password validation:** Added checks to ensure that the current password is valid and the new password meets security requirements.
- **Authorization check:** Added a validation to ensure that only the profile owner or an admin can update the password, using a service method for verification.
- **API documentation:** Documented the new endpoint using Swagger, including request and response structures for the password update operation.
- **Unit tests:** Added unit tests to validate the password update flow, ensuring that only authorized users (owners or admins) can update passwords and the inputs are properly validated.