### PR TITLE
Create endpoint to request a service

### DIFF
--- a/src/main/java/br/com/conectabyte/profissu/controllers/RequestedServiceController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/RequestedServiceController.java
@@ -1,9 +1,11 @@
 package br.com.conectabyte.profissu.controllers;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,8 +14,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import br.com.conectabyte.profissu.dtos.request.RequestedServiceRequestDto;
+import br.com.conectabyte.profissu.dtos.response.ExceptionDto;
 import br.com.conectabyte.profissu.dtos.response.RequestedServiceResponseDto;
 import br.com.conectabyte.profissu.services.RequestedServiceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -23,11 +31,23 @@ import lombok.RequiredArgsConstructor;
 public class RequestedServiceController {
   private final RequestedServiceService requestedServiceService;
 
+  @Operation(summary = "List requested services with pagination", description = "Retrieve a paginated list of requested services.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Successful retrieval of requested services", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Page.class))),
+      @ApiResponse(responseCode = "400", description = "Invalid pagination parameters", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+  })
   @GetMapping
-  public Page<RequestedServiceResponseDto> findByPage(Pageable pageable) {
+  public Page<RequestedServiceResponseDto> findByPage(@ParameterObject Pageable pageable) {
     return requestedServiceService.findByPage(pageable);
   }
 
+  @Operation(summary = "Register a requested service", description = "Allows a user to register a new requested service.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "Successfully created requested service", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RequestedServiceResponseDto.class))),
+      @ApiResponse(responseCode = "400", description = "Invalid request format or missing required fields", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "404", description = "User not found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+  })
+  @PreAuthorize("@securityService.isOwner(#id) || @securityService.isAdmin()")
   @PostMapping("/{userId}")
   public ResponseEntity<RequestedServiceResponseDto> register(@PathVariable Long userId,
       @Valid @RequestBody RequestedServiceRequestDto requestedServiceRequestDto) {

--- a/src/main/java/br/com/conectabyte/profissu/controllers/RequestedServiceController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/RequestedServiceController.java
@@ -1,0 +1,29 @@
+package br.com.conectabyte.profissu.controllers;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.conectabyte.profissu.dtos.request.RequestedServiceRequestDto;
+import br.com.conectabyte.profissu.dtos.response.RequestedServiceResponseDto;
+import br.com.conectabyte.profissu.services.RequestedServiceService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/requested-services")
+@RequiredArgsConstructor
+public class RequestedServiceController {
+  private final RequestedServiceService requestedServiceService;
+
+  @PostMapping("/{userId}")
+  public ResponseEntity<RequestedServiceResponseDto> register(@PathVariable Long userId,
+      @Valid @RequestBody RequestedServiceRequestDto requestedServiceRequestDto) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(this.requestedServiceService.register(userId, requestedServiceRequestDto));
+  }
+}

--- a/src/main/java/br/com/conectabyte/profissu/controllers/RequestedServiceController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/RequestedServiceController.java
@@ -1,7 +1,10 @@
 package br.com.conectabyte.profissu.controllers;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +22,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RequestedServiceController {
   private final RequestedServiceService requestedServiceService;
+
+  @GetMapping
+  public Page<RequestedServiceResponseDto> findByPage(Pageable pageable) {
+    return requestedServiceService.findByPage(pageable);
+  }
 
   @PostMapping("/{userId}")
   public ResponseEntity<RequestedServiceResponseDto> register(@PathVariable Long userId,

--- a/src/main/java/br/com/conectabyte/profissu/dtos/request/RequestedServiceRequestDto.java
+++ b/src/main/java/br/com/conectabyte/profissu/dtos/request/RequestedServiceRequestDto.java
@@ -1,0 +1,11 @@
+package br.com.conectabyte.profissu.dtos.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record RequestedServiceRequestDto(
+    @NotBlank(message = "title: Cannot be null or empty") String title,
+    @NotBlank(message = "description: Cannot be null or empty") String description,
+    @Valid @NotNull(message = "address: Cannot be null") AddressRequestDto address) {
+}

--- a/src/main/java/br/com/conectabyte/profissu/dtos/response/RequestedServiceResponseDto.java
+++ b/src/main/java/br/com/conectabyte/profissu/dtos/response/RequestedServiceResponseDto.java
@@ -1,0 +1,7 @@
+package br.com.conectabyte.profissu.dtos.response;
+
+import br.com.conectabyte.profissu.enums.RequestedServiceStatusEnum;
+
+public record RequestedServiceResponseDto(Long id, String title, String description, RequestedServiceStatusEnum status,
+    AddressResponseDto address, Long requesterId) {
+}

--- a/src/main/java/br/com/conectabyte/profissu/entities/RequestedService.java
+++ b/src/main/java/br/com/conectabyte/profissu/entities/RequestedService.java
@@ -2,8 +2,12 @@ package br.com.conectabyte.profissu.entities;
 
 import java.time.LocalDateTime;
 
+import br.com.conectabyte.profissu.enums.RequestedServiceStatusEnum;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,10 +31,20 @@ public class RequestedService {
   @Column(name = "updated_at")
   private LocalDateTime updatedAt;
 
+  @Column(nullable = false)
+  private String title;
+
+  @Column(nullable = false)
+  private String description;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private RequestedServiceStatusEnum status;
+
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
-  @OneToOne
+  @OneToOne(cascade = CascadeType.ALL)
   @JoinColumn(name = "address_id", nullable = false)
   private Address address;
 

--- a/src/main/java/br/com/conectabyte/profissu/enums/RequestedServiceStatusEnum.java
+++ b/src/main/java/br/com/conectabyte/profissu/enums/RequestedServiceStatusEnum.java
@@ -1,0 +1,8 @@
+package br.com.conectabyte.profissu.enums;
+
+public enum RequestedServiceStatusEnum {
+  PENDING,
+  INPROGRESS,
+  DONE,
+  CANCELLED
+}

--- a/src/main/java/br/com/conectabyte/profissu/handlers/RestExceptionHandler.java
+++ b/src/main/java/br/com/conectabyte/profissu/handlers/RestExceptionHandler.java
@@ -2,6 +2,7 @@ package br.com.conectabyte.profissu.handlers;
 
 import java.util.ArrayList;
 
+import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -22,7 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestControllerAdvice
 public class RestExceptionHandler {
-  @ExceptionHandler({ MethodArgumentNotValidException.class })
+  @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ExceptionDto> validationExceptionHandler(MethodArgumentNotValidException e) {
     log.error("Error: {}", e.getMessage());
     val errors = new ArrayList<String>();
@@ -30,13 +31,20 @@ public class RestExceptionHandler {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ExceptionDto("All fields must be valid", errors));
   }
 
-  @ExceptionHandler({ HttpMessageNotReadableException.class })
+  @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<ExceptionDto> malformedExceptionHandler(Exception e) {
     log.error("Error: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ExceptionDto("Malformed json", null));
   }
 
-  @ExceptionHandler({ ValidationException.class })
+  @ExceptionHandler(PropertyReferenceException.class)
+  public ResponseEntity<ExceptionDto> handleInvalidSortField(PropertyReferenceException e) {
+    log.error("Error: {}", e.getMessage());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(new ExceptionDto("No property '" + e.getPropertyName() + "' found", null));
+  }
+
+  @ExceptionHandler(ValidationException.class)
   public ResponseEntity<ExceptionDto> validationExceptionHandler(Exception e) {
     log.error("Error: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ExceptionDto(e.getMessage(), null));

--- a/src/main/java/br/com/conectabyte/profissu/mappers/RequestedServiceMapper.java
+++ b/src/main/java/br/com/conectabyte/profissu/mappers/RequestedServiceMapper.java
@@ -3,6 +3,8 @@ package br.com.conectabyte.profissu.mappers;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 
 import br.com.conectabyte.profissu.dtos.request.RequestedServiceRequestDto;
 import br.com.conectabyte.profissu.dtos.response.RequestedServiceResponseDto;
@@ -23,4 +25,14 @@ public interface RequestedServiceMapper {
   @Mapping(source = "user", target = "requesterId", qualifiedByName = "matUserToId")
   RequestedServiceResponseDto requestedServiceToRequestedServiceResponseDto(
       RequestedService requestedServiceRequestDto);
+
+  default Page<RequestedServiceResponseDto> RequestedServicePageToRequestedServiceResponseDtoPage(
+      Page<RequestedService> requestedServicePage) {
+    final var requestedServiceResponseDtoPageContent = requestedServicePage.getContent().stream()
+        .map(this::requestedServiceToRequestedServiceResponseDto)
+        .toList();
+
+    return new PageImpl<>(requestedServiceResponseDtoPageContent, requestedServicePage.getPageable(),
+        requestedServicePage.getTotalElements());
+  }
 }

--- a/src/main/java/br/com/conectabyte/profissu/mappers/RequestedServiceMapper.java
+++ b/src/main/java/br/com/conectabyte/profissu/mappers/RequestedServiceMapper.java
@@ -1,0 +1,26 @@
+package br.com.conectabyte.profissu.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import br.com.conectabyte.profissu.dtos.request.RequestedServiceRequestDto;
+import br.com.conectabyte.profissu.dtos.response.RequestedServiceResponseDto;
+import br.com.conectabyte.profissu.entities.RequestedService;
+
+@Mapper(uses = { UserMapper.class, AddressMapper.class })
+public interface RequestedServiceMapper {
+  RequestedServiceMapper INSTANCE = Mappers.getMapper(RequestedServiceMapper.class);
+
+  @Mapping(target = "createdAt", ignore = true)
+  @Mapping(target = "deletedAt", ignore = true)
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "updatedAt", ignore = true)
+  @Mapping(target = "user", ignore = true)
+  @Mapping(target = "status", ignore = true)
+  RequestedService requestedServiceRequestDtoToRequestedService(RequestedServiceRequestDto requestedServiceRequestDto);
+
+  @Mapping(source = "user", target = "requesterId", qualifiedByName = "matUserToId")
+  RequestedServiceResponseDto requestedServiceToRequestedServiceResponseDto(
+      RequestedService requestedServiceRequestDto);
+}

--- a/src/main/java/br/com/conectabyte/profissu/mappers/UserMapper.java
+++ b/src/main/java/br/com/conectabyte/profissu/mappers/UserMapper.java
@@ -2,6 +2,7 @@ package br.com.conectabyte.profissu.mappers;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
 import br.com.conectabyte.profissu.dtos.request.UserRequestDto;
@@ -38,4 +39,9 @@ public interface UserMapper {
   User userResponseDtoToUser(UserResponseDto userResponseDto);
 
   UserResponseDto userToUserResponseDto(User user);
+
+  @Named("matUserToId")
+  default Long matUserToId(User user) {
+    return user.getId();
+  }
 }

--- a/src/main/java/br/com/conectabyte/profissu/repositories/RequestedServiceRepository.java
+++ b/src/main/java/br/com/conectabyte/profissu/repositories/RequestedServiceRepository.java
@@ -1,0 +1,8 @@
+package br.com.conectabyte.profissu.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import br.com.conectabyte.profissu.entities.RequestedService;
+
+public interface RequestedServiceRepository extends JpaRepository<RequestedService, Long> {
+}

--- a/src/main/java/br/com/conectabyte/profissu/services/RequestedServiceService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/RequestedServiceService.java
@@ -1,0 +1,34 @@
+package br.com.conectabyte.profissu.services;
+
+import org.springframework.stereotype.Service;
+
+import br.com.conectabyte.profissu.dtos.request.RequestedServiceRequestDto;
+import br.com.conectabyte.profissu.dtos.response.RequestedServiceResponseDto;
+import br.com.conectabyte.profissu.enums.RequestedServiceStatusEnum;
+import br.com.conectabyte.profissu.mappers.RequestedServiceMapper;
+import br.com.conectabyte.profissu.repositories.RequestedServiceRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RequestedServiceService {
+  private final RequestedServiceRepository requestedServiceRepository;
+  private final UserService userService;
+
+  private final RequestedServiceMapper requestedServiceMapper = RequestedServiceMapper.INSTANCE;
+
+  @Transactional
+  public RequestedServiceResponseDto register(Long userId, RequestedServiceRequestDto requestedServiceRequestDto) {
+    final var user = userService.findById(userId);
+    final var requestedServiceToBeSaved = requestedServiceMapper
+        .requestedServiceRequestDtoToRequestedService(requestedServiceRequestDto);
+
+    requestedServiceToBeSaved.setStatus(RequestedServiceStatusEnum.PENDING);
+    requestedServiceToBeSaved.setUser(user);
+
+    final var requestedService = requestedServiceRepository.save(requestedServiceToBeSaved);
+
+    return requestedServiceMapper.requestedServiceToRequestedServiceResponseDto(requestedService);
+  }
+}

--- a/src/main/java/br/com/conectabyte/profissu/services/RequestedServiceService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/RequestedServiceService.java
@@ -1,5 +1,7 @@
 package br.com.conectabyte.profissu.services;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import br.com.conectabyte.profissu.dtos.request.RequestedServiceRequestDto;
@@ -7,7 +9,6 @@ import br.com.conectabyte.profissu.dtos.response.RequestedServiceResponseDto;
 import br.com.conectabyte.profissu.enums.RequestedServiceStatusEnum;
 import br.com.conectabyte.profissu.mappers.RequestedServiceMapper;
 import br.com.conectabyte.profissu.repositories.RequestedServiceRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -18,7 +19,11 @@ public class RequestedServiceService {
 
   private final RequestedServiceMapper requestedServiceMapper = RequestedServiceMapper.INSTANCE;
 
-  @Transactional
+  public Page<RequestedServiceResponseDto> findByPage(Pageable pageable) {
+    return requestedServiceMapper
+        .RequestedServicePageToRequestedServiceResponseDtoPage(requestedServiceRepository.findAll(pageable));
+  }
+
   public RequestedServiceResponseDto register(Long userId, RequestedServiceRequestDto requestedServiceRequestDto) {
     final var user = userService.findById(userId);
     final var requestedServiceToBeSaved = requestedServiceMapper

--- a/src/test/java/br/com/conectabyte/profissu/controllers/AddressControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/AddressControllerTest.java
@@ -1,7 +1,6 @@
 package br.com.conectabyte.profissu.controllers;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -55,8 +54,8 @@ class AddressControllerTest {
   @Test
   @WithMockUser
   void shouldRegisterAddressWhenUserIsOwnerOrAdmin() throws Exception {
-    when(addressService.register(anyLong(), any())).thenReturn(responseDto);
-    when(securityService.isOwner(anyLong())).thenReturn(true);
+    when(addressService.register(any(), any())).thenReturn(responseDto);
+    when(securityService.isOwner(any())).thenReturn(true);
 
     mockMvc.perform(post("/addresses/" + userId)
         .contentType(MediaType.APPLICATION_JSON)
@@ -88,7 +87,7 @@ class AddressControllerTest {
   @Test
   @WithMockUser
   void shouldReturnForbiddenWhenUserHasNoPermission() throws Exception {
-    when(securityService.isOwner(anyLong())).thenReturn(false);
+    when(securityService.isOwner(any())).thenReturn(false);
     when(securityService.isAdmin()).thenReturn(false);
 
     mockMvc.perform(post("/addresses/" + userId)
@@ -101,8 +100,8 @@ class AddressControllerTest {
   @Test
   @WithMockUser
   void shouldUpdateAddressWhenUserIsOwnerOrAdmin() throws Exception {
-    when(addressService.update(anyLong(), any())).thenReturn(responseDto);
-    when(securityService.isOwnerOfAddress(anyLong())).thenReturn(true);
+    when(addressService.update(any(), any())).thenReturn(responseDto);
+    when(securityService.isOwnerOfAddress(any())).thenReturn(true);
 
     mockMvc.perform(put("/addresses/" + addressId)
         .contentType(MediaType.APPLICATION_JSON)
@@ -114,8 +113,8 @@ class AddressControllerTest {
   @Test
   @WithMockUser
   void shouldReturnNotFoundWhenAddressDoesNotExist() throws Exception {
-    when(addressService.update(anyLong(), any())).thenThrow(new ResourceNotFoundException("Address not found"));
-    when(securityService.isOwnerOfAddress(anyLong())).thenReturn(true);
+    when(addressService.update(any(), any())).thenThrow(new ResourceNotFoundException("Address not found"));
+    when(securityService.isOwnerOfAddress(any())).thenReturn(true);
 
     mockMvc.perform(put("/addresses/" + addressId)
         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/br/com/conectabyte/profissu/controllers/RequestedServiceControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/RequestedServiceControllerTest.java
@@ -1,0 +1,120 @@
+package br.com.conectabyte.profissu.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import br.com.conectabyte.profissu.config.SecurityConfig;
+import br.com.conectabyte.profissu.dtos.request.RequestedServiceRequestDto;
+import br.com.conectabyte.profissu.dtos.response.RequestedServiceResponseDto;
+import br.com.conectabyte.profissu.enums.RequestedServiceStatusEnum;
+import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
+import br.com.conectabyte.profissu.mappers.AddressMapper;
+import br.com.conectabyte.profissu.services.RequestedServiceService;
+import br.com.conectabyte.profissu.services.SecurityService;
+import br.com.conectabyte.profissu.utils.AddressUtils;
+import br.com.conectabyte.profissu.utils.UserUtils;
+
+@WebMvcTest({ RequestedServiceController.class, SecurityService.class })
+@Import(SecurityConfig.class)
+class RequestedServiceControllerTest {
+  @MockBean
+  private RequestedServiceService requestedServiceService;
+
+  @MockBean
+  private SecurityService securityService;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  @WithMockUser
+  void shouldFindByPage() throws Exception {
+    Page<RequestedServiceResponseDto> expectedPage = new PageImpl<>(List.of(
+        new RequestedServiceResponseDto(1L, "Title", "Description", RequestedServiceStatusEnum.PENDING, null, 1L)));
+
+    when(requestedServiceService.findByPage(any(Pageable.class))).thenReturn(expectedPage);
+
+    mockMvc.perform(get("/requested-services")
+        .param("page", "0")
+        .param("size", "10")
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].title").value("Title"));
+  }
+
+  @Test
+  @WithMockUser
+  void shouldRegisterRequestedService() throws Exception {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+    final var addressRequestDto = AddressMapper.INSTANCE.addressToAddressRequestDto(address);
+    final var addressResponseDto = AddressMapper.INSTANCE.addressToAddressResponseDto(address);
+    final var requestedServiceRequestDto = new RequestedServiceRequestDto("Title", "Description",
+        addressRequestDto);
+    final var RequestedServiceResponseDto = new RequestedServiceResponseDto(1L, "Title",
+        "Description",
+        RequestedServiceStatusEnum.PENDING, addressResponseDto, user.getId());
+
+    when(securityService.isOwner(any())).thenReturn(true);
+    when(requestedServiceService.register(any(), any())).thenReturn(RequestedServiceResponseDto);
+
+    mockMvc.perform(post("/requested-services/{userId}", user.getId())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(requestedServiceRequestDto)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.title").value("Title"));
+  }
+
+  @Test
+  @WithMockUser
+  void shouldReturnNotFoundWhenUserDoesNotExist() throws Exception {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+    final var addressRequestDto = AddressMapper.INSTANCE.addressToAddressRequestDto(address);
+    final var requestedServiceRequestDto = new RequestedServiceRequestDto("Title", "Description",
+        addressRequestDto);
+
+    when(securityService.isOwner(any())).thenReturn(true);
+    when(requestedServiceService.register(any(), any())).thenThrow(new ResourceNotFoundException("User not found."));
+
+    mockMvc.perform(post("/requested-services/{userId}", user.getId())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(requestedServiceRequestDto)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("User not found."));
+  }
+
+  @Test
+  @WithMockUser
+  void shouldReturnBadRequestForInvalidInput() throws Exception {
+    final var requestedServiceRequestDto = new RequestedServiceRequestDto("", "", null);
+
+    mockMvc.perform(post("/requested-services/{userId}", 1L)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(requestedServiceRequestDto)))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/services/RequestedServiceServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/RequestedServiceServiceTest.java
@@ -1,0 +1,102 @@
+package br.com.conectabyte.profissu.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import br.com.conectabyte.profissu.dtos.request.RequestedServiceRequestDto;
+import br.com.conectabyte.profissu.dtos.response.RequestedServiceResponseDto;
+import br.com.conectabyte.profissu.entities.RequestedService;
+import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
+import br.com.conectabyte.profissu.mappers.AddressMapper;
+import br.com.conectabyte.profissu.repositories.RequestedServiceRepository;
+import br.com.conectabyte.profissu.utils.AddressUtils;
+import br.com.conectabyte.profissu.utils.RequestedServiceUtils;
+import br.com.conectabyte.profissu.utils.UserUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RequestedServiceServiceTest {
+  @Mock
+  private RequestedServiceRepository requestedServiceRepository;
+
+  @Mock
+  private UserService userService;
+
+  @InjectMocks
+  private RequestedServiceService requestedServiceService;
+
+  @Test
+  void shouldFindByPage() {
+    final var pageable = PageRequest.of(0, 10);
+    final var requestedService = new RequestedService();
+    final var user = UserUtils.create();
+
+    requestedService.setUser(user);
+
+    final var requestedServicePage = new PageImpl<>(List.of(requestedService));
+
+    when(requestedServiceRepository.findAll(pageable)).thenReturn(requestedServicePage);
+
+    Page<RequestedServiceResponseDto> result = requestedServiceService.findByPage(pageable);
+
+    assertNotNull(result);
+    assertEquals(1, result.getTotalElements());
+  }
+
+  @Test
+  void shouldRegisterRequestedService() {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+    final var addressRequestDto = AddressMapper.INSTANCE.addressToAddressRequestDto(address);
+    final var requestedServiceRequestDto = new RequestedServiceRequestDto("Title", "Description", addressRequestDto);
+    final var requestedService = RequestedServiceUtils.create(user, address);
+
+    requestedService.setUser(user);
+
+    when(userService.findById(any())).thenReturn(user);
+    when(requestedServiceRepository.save(any())).thenReturn(requestedService);
+
+    final var result = requestedServiceService.register(user.getId(), requestedServiceRequestDto);
+
+    assertNotNull(result);
+    assertEquals("Title", result.title());
+  }
+
+  @Test
+  void shouldThrowExceptionWhenUserNotFound() {
+    Long userId = 1L;
+    RequestedServiceRequestDto requestDto = new RequestedServiceRequestDto("Title", "Description", null);
+
+    when(userService.findById(userId)).thenThrow(new ResourceNotFoundException("User not found."));
+
+    Exception exception = assertThrows(ResourceNotFoundException.class,
+        () -> requestedServiceService.register(userId, requestDto));
+    assertEquals("User not found.", exception.getMessage());
+  }
+
+  @Test
+  void shouldReturnEmptyPageWhenNoResultsFound() {
+    final var pageable = PageRequest.of(0, 10);
+    final Page<RequestedService> emptyPage = Page.empty();
+
+    when(requestedServiceRepository.findAll(pageable)).thenReturn(emptyPage);
+
+    final var result = requestedServiceService.findByPage(pageable);
+
+    assertNotNull(result);
+    assertEquals(0, result.getTotalElements());
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/utils/RequestedServiceUtils.java
+++ b/src/test/java/br/com/conectabyte/profissu/utils/RequestedServiceUtils.java
@@ -1,0 +1,21 @@
+package br.com.conectabyte.profissu.utils;
+
+import br.com.conectabyte.profissu.entities.Address;
+import br.com.conectabyte.profissu.entities.RequestedService;
+import br.com.conectabyte.profissu.entities.User;
+import br.com.conectabyte.profissu.enums.RequestedServiceStatusEnum;
+
+public class RequestedServiceUtils {
+  public static RequestedService create(User user, Address address) {
+    final var requestedService = new RequestedService();
+
+    requestedService.setId(0L);
+    requestedService.setTitle("Title");
+    requestedService.setDescription("Description");
+    requestedService.setStatus(RequestedServiceStatusEnum.PENDING);
+    requestedService.setAddress(address);
+    requestedService.setUser(user);
+
+    return requestedService;
+  }
+}


### PR DESCRIPTION
### Description
This PR adds endpoints for registering and retrieving requested services. The retrieval endpoint supports pagination. Additionally, all endpoints are fully documented and covered by unit tests.

### Main Changes
- **Created service request registration endpoint** – Allows users to register new requested services.
- **Created paginated service request retrieval endpoint** – Enables listing of requested services with pagination.
- **Added API documentation** – Documented all endpoints using Swagger.
- **Implemented unit tests** – Covered logic with unit tests to ensure expected behavior.