### PR TITLE
Create endpoint to list available service requests

### DIFF
--- a/src/main/java/br/com/conectabyte/profissu/controllers/RequestedServiceController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/RequestedServiceController.java
@@ -38,8 +38,8 @@ public class RequestedServiceController {
       @ApiResponse(responseCode = "400", description = "Invalid pagination parameters", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
   })
   @GetMapping
-  public Page<RequestedServiceResponseDto> findByPage(@ParameterObject Pageable pageable) {
-    return requestedServiceService.findByPage(pageable);
+  public Page<RequestedServiceResponseDto> findAvailableServiceRequestsByPage(@ParameterObject Pageable pageable) {
+    return requestedServiceService.findAvailableServiceRequestsByPage(pageable);
   }
 
   @Operation(summary = "Register a requested service", description = "Allows a user to register a new requested service.")

--- a/src/main/java/br/com/conectabyte/profissu/repositories/RequestedServiceRepository.java
+++ b/src/main/java/br/com/conectabyte/profissu/repositories/RequestedServiceRepository.java
@@ -1,8 +1,17 @@
 package br.com.conectabyte.profissu.repositories;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import br.com.conectabyte.profissu.entities.RequestedService;
 
 public interface RequestedServiceRepository extends JpaRepository<RequestedService, Long> {
+  @Query("""
+      FROM RequestedService rs
+        WHERE rs.status = 'PENDING'
+        AND rs.deletedAt IS NULL
+      """)
+  Page<RequestedService> findAvailableServiceRequestsByPage(Pageable pageable);
 }

--- a/src/main/java/br/com/conectabyte/profissu/services/RequestedServiceService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/RequestedServiceService.java
@@ -36,9 +36,9 @@ public class RequestedServiceService {
   }
 
   @Transactional
-  public Page<RequestedServiceResponseDto> findByPage(Pageable pageable) {
-    return requestedServiceMapper
-        .RequestedServicePageToRequestedServiceResponseDtoPage(requestedServiceRepository.findAll(pageable));
+  public Page<RequestedServiceResponseDto> findAvailableServiceRequestsByPage(Pageable pageable) {
+    final var availableServiceRequests = requestedServiceRepository.findAvailableServiceRequestsByPage(pageable);
+    return requestedServiceMapper.RequestedServicePageToRequestedServiceResponseDtoPage(availableServiceRequests);
   }
 
   @Transactional

--- a/src/test/java/br/com/conectabyte/profissu/controllers/RequestedServiceControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/RequestedServiceControllerTest.java
@@ -60,7 +60,7 @@ class RequestedServiceControllerTest {
     final var expectedPage = new PageImpl<>(List.of(new RequestedServiceResponseDto(1L, "Title",
         "Description", RequestedServiceStatusEnum.PENDING, addressResponseDto, userResponseDto, null)));
 
-    when(requestedServiceService.findByPage(any(Pageable.class))).thenReturn(expectedPage);
+    when(requestedServiceService.findAvailableServiceRequestsByPage(any(Pageable.class))).thenReturn(expectedPage);
 
     mockMvc.perform(get("/requested-services")
         .param("page", "0")

--- a/src/test/java/br/com/conectabyte/profissu/repositories/AddressRepositoryTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/repositories/AddressRepositoryTest.java
@@ -1,0 +1,71 @@
+package br.com.conectabyte.profissu.repositories;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import br.com.conectabyte.profissu.utils.AddressUtils;
+import br.com.conectabyte.profissu.utils.UserUtils;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class AddressRepositoryTest {
+  @Autowired
+  private AddressRepository addressRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Test
+  public void shouldReturnAddressByIdWhenIsNotDeletedAndExists() {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+    address.setId(1L);
+
+    user.setAddresses(List.of(address));
+    userRepository.save(user);
+
+    final var findedAddress = addressRepository.findById(1L);
+
+    assertTrue(findedAddress.isPresent());
+  }
+
+  @Test
+  public void shouldReturnEmptyWhenAddressIsDeleted() {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+    address.setId(1L);
+
+    user.setAddresses(List.of(address));
+
+    final var savedUser = userRepository.save(user);
+
+    savedUser.getAddresses().get(0).setDeletedAt(LocalDateTime.now());
+
+    final var findedAddress = addressRepository.findById(1L);
+
+    assertTrue(findedAddress.isEmpty());
+  }
+
+  @Test
+  public void shouldReturnEmptyWhenAddressNotFound() {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+    address.setId(1L);
+
+    user.setAddresses(List.of(address));
+    userRepository.save(user);
+
+    final var findedAddress = addressRepository.findById(0L);
+
+    assertTrue(findedAddress.isEmpty());
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/repositories/ContactRepositoryTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/repositories/ContactRepositoryTest.java
@@ -1,0 +1,116 @@
+package br.com.conectabyte.profissu.repositories;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import br.com.conectabyte.profissu.utils.ContactUtils;
+import br.com.conectabyte.profissu.utils.UserUtils;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class ContactRepositoryTest {
+  @Autowired
+  private ContactRepository contactRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Test
+  public void shouldReturnContactByIdWhenIsNotDeletedAndExists() {
+    final var user = UserUtils.create();
+    final var contact = ContactUtils.create(user);
+    contact.setId(1L);
+
+    user.setContacts(List.of(contact));
+    userRepository.save(user);
+
+    final var findedContact = contactRepository.findById(1L);
+
+    assertTrue(findedContact.isPresent());
+  }
+
+  @Test
+  public void shouldReturnEmptyByIdWhenContactIsDeleted() {
+    final var user = UserUtils.create();
+    final var contact = ContactUtils.create(user);
+    contact.setId(1L);
+
+    user.setContacts(List.of(contact));
+
+    final var savedUser = userRepository.save(user);
+
+    savedUser.getContacts().get(0).setDeletedAt(LocalDateTime.now());
+
+    final var findedContact = contactRepository.findById(1L);
+
+    assertTrue(findedContact.isEmpty());
+  }
+
+  @Test
+  public void shouldReturnEmptyByIdWhenContactNotFound() {
+    final var user = UserUtils.create();
+    final var contact = ContactUtils.create(user);
+    contact.setId(1L);
+
+    user.setContacts(List.of(contact));
+    userRepository.save(user);
+
+    final var findedContact = contactRepository.findById(0L);
+
+    assertTrue(findedContact.isEmpty());
+  }
+
+  @Test
+  public void shouldReturnContactByValueWhenIsNotDeletedAndExists() {
+    final var user = UserUtils.create();
+    final var contact = ContactUtils.create(user);
+    contact.setId(1L);
+
+    user.setContacts(List.of(contact));
+    userRepository.save(user);
+
+    final var findedContact = contactRepository.findByValue(contact.getValue());
+
+    assertTrue(findedContact.isPresent());
+  }
+
+  @Test
+  public void shouldReturnEmptyByValueWhenContactIsDeleted() {
+    final var user = UserUtils.create();
+    final var contact = ContactUtils.create(user);
+    contact.setId(1L);
+
+    user.setContacts(List.of(contact));
+
+    final var savedUser = userRepository.save(user);
+
+    savedUser.getContacts().get(0).setDeletedAt(LocalDateTime.now());
+
+    final var findedContact = contactRepository.findByValue(contact.getValue());
+
+    assertTrue(findedContact.isEmpty());
+  }
+
+  @Test
+  public void shouldReturnEmptyByValueWhenContactNotFound() {
+    final var user = UserUtils.create();
+    final var contact = ContactUtils.create(user);
+    contact.setId(1L);
+
+    user.setContacts(List.of(contact));
+    userRepository.save(user);
+
+    final var findedContact = contactRepository.findByValue("invalid@conectabyte.com.br");
+
+    assertTrue(findedContact.isEmpty());
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/repositories/RequestedServiceRepositoryTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/repositories/RequestedServiceRepositoryTest.java
@@ -1,0 +1,87 @@
+package br.com.conectabyte.profissu.repositories;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+import br.com.conectabyte.profissu.enums.RequestedServiceStatusEnum;
+import br.com.conectabyte.profissu.utils.AddressUtils;
+import br.com.conectabyte.profissu.utils.ContactUtils;
+import br.com.conectabyte.profissu.utils.RequestedServiceUtils;
+import br.com.conectabyte.profissu.utils.UserUtils;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class RequestedServiceRepositoryTest {
+  @Autowired
+  private RequestedServiceRepository requestedServiceRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Test
+  public void shouldReturnRequestedServicePageWhenHavePandingRequestServices() {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+
+    user.setContacts(List.of(ContactUtils.create(user)));
+    user.setAddresses(List.of(address));
+
+    final var savedUser = userRepository.save(user);
+    final var requestedService = RequestedServiceUtils.create(savedUser, savedUser.getAddresses().get(0));
+
+    requestedServiceRepository.save(requestedService);
+
+    final var requestedServicePage = requestedServiceRepository.findAvailableServiceRequestsByPage(Pageable.ofSize(10));
+
+    assertTrue(requestedServicePage.getTotalElements() > 0);
+  }
+
+  @Test
+  public void shouldReturnVoidPageWhenNotHavePandingRequestServices() {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+
+    user.setContacts(List.of(ContactUtils.create(user)));
+    user.setAddresses(List.of(address));
+
+    final var savedUser = userRepository.save(user);
+    final var requestedService = RequestedServiceUtils.create(savedUser, savedUser.getAddresses().get(0));
+
+    requestedService.setStatus(RequestedServiceStatusEnum.DONE);
+    requestedServiceRepository.save(requestedService);
+
+    final var requestedServicePage = requestedServiceRepository.findAvailableServiceRequestsByPage(Pageable.ofSize(10));
+
+    assertEquals(requestedServicePage.getTotalElements(), 0);
+  }
+
+  @Test
+  public void shouldReturnVoidPageWhenRequestServiceIsDeleted() {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+
+    user.setContacts(List.of(ContactUtils.create(user)));
+    user.setAddresses(List.of(address));
+
+    final var savedUser = userRepository.save(user);
+    final var requestedService = RequestedServiceUtils.create(savedUser, savedUser.getAddresses().get(0));
+
+    requestedService.setDeletedAt(LocalDateTime.now());
+    requestedServiceRepository.save(requestedService);
+
+    final var requestedServicePage = requestedServiceRepository.findAvailableServiceRequestsByPage(Pageable.ofSize(10));
+
+    assertEquals(requestedServicePage.getTotalElements(), 0);
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/services/RequestedServiceServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/RequestedServiceServiceTest.java
@@ -59,7 +59,7 @@ class RequestedServiceServiceTest {
 
     final var requestedServicePage = new PageImpl<>(List.of(requestedService));
 
-    when(requestedServiceRepository.findAll(pageable)).thenReturn(requestedServicePage);
+    when(requestedServiceRepository.findAvailableServiceRequestsByPage(pageable)).thenReturn(requestedServicePage);
 
     Page<RequestedServiceResponseDto> result = requestedServiceService.findAvailableServiceRequestsByPage(pageable);
 
@@ -103,7 +103,7 @@ class RequestedServiceServiceTest {
     final var pageable = PageRequest.of(0, 10);
     final Page<RequestedService> emptyPage = Page.empty();
 
-    when(requestedServiceRepository.findAll(pageable)).thenReturn(emptyPage);
+    when(requestedServiceRepository.findAvailableServiceRequestsByPage(pageable)).thenReturn(emptyPage);
 
     final var result = requestedServiceService.findAvailableServiceRequestsByPage(pageable);
 

--- a/src/test/java/br/com/conectabyte/profissu/services/RequestedServiceServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/RequestedServiceServiceTest.java
@@ -61,7 +61,7 @@ class RequestedServiceServiceTest {
 
     when(requestedServiceRepository.findAll(pageable)).thenReturn(requestedServicePage);
 
-    Page<RequestedServiceResponseDto> result = requestedServiceService.findByPage(pageable);
+    Page<RequestedServiceResponseDto> result = requestedServiceService.findAvailableServiceRequestsByPage(pageable);
 
     assertNotNull(result);
     assertEquals(1, result.getTotalElements());
@@ -105,7 +105,7 @@ class RequestedServiceServiceTest {
 
     when(requestedServiceRepository.findAll(pageable)).thenReturn(emptyPage);
 
-    final var result = requestedServiceService.findByPage(pageable);
+    final var result = requestedServiceService.findAvailableServiceRequestsByPage(pageable);
 
     assertNotNull(result);
     assertEquals(0, result.getTotalElements());


### PR DESCRIPTION
### Description
This PR adds an endpoint to retrieve a list of available service requests. The endpoint filters out requests that are not currently available, ensuring that only relevant requests are returned to the user.

### Main Changes
- **Implemented new endpoint:** Created an API endpoint to list available service requests.
- **Updated unit tests:** Added unit tests to cover the new endpoint functionality.