### PR TITLE
Create endpoint for viewing user activity history

### DIFF
--- a/src/main/java/br/com/conectabyte/profissu/controllers/RequestedServiceController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/RequestedServiceController.java
@@ -38,8 +38,8 @@ public class RequestedServiceController {
       @ApiResponse(responseCode = "400", description = "Invalid pagination parameters", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
   })
   @GetMapping
-  public Page<RequestedServiceResponseDto> findAvailableServiceRequestsByPage(@ParameterObject Pageable pageable) {
-    return requestedServiceService.findAvailableServiceRequestsByPage(pageable);
+  public Page<RequestedServiceResponseDto> findAvailableServiceRequests(@ParameterObject Pageable pageable) {
+    return requestedServiceService.findAvailableServiceRequests(pageable);
   }
 
   @Operation(summary = "Register a requested service", description = "Allows a user to register a new requested service.")

--- a/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
@@ -49,6 +49,10 @@ public class UserController {
     return ResponseEntity.ok().body(this.userService.findByIdAndReturnDto(id));
   }
 
+  @Operation(summary = "Retrieve requested services by user ID", description = "Fetches a paginated list of requested services associated with the provided user ID.", responses = {
+      @ApiResponse(responseCode = "200", description = "Successfully retrieved requested services", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Page.class))),
+      @ApiResponse(responseCode = "400", description = "Invalid pagination parameters", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+  })
   @GetMapping("/{id}/requested-services")
   public Page<RequestedServiceResponseDto> findRequestedServiceByUserId(@PathVariable Long id,
       @ParameterObject Pageable pageable) {

--- a/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
@@ -1,5 +1,8 @@
 package br.com.conectabyte.profissu.controllers;
 
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,7 +17,9 @@ import org.springframework.web.bind.annotation.RestController;
 import br.com.conectabyte.profissu.dtos.request.PasswordRequestDto;
 import br.com.conectabyte.profissu.dtos.request.ProfileRequestDto;
 import br.com.conectabyte.profissu.dtos.response.ExceptionDto;
+import br.com.conectabyte.profissu.dtos.response.RequestedServiceResponseDto;
 import br.com.conectabyte.profissu.dtos.response.UserResponseDto;
+import br.com.conectabyte.profissu.services.RequestedServiceService;
 import br.com.conectabyte.profissu.services.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -30,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Users", description = "Operations related to managing users")
 public class UserController {
   private final UserService userService;
+  private final RequestedServiceService requestedServiceService;
 
   @Operation(summary = "Retrieve user by ID", description = "Fetches a user's details using the provided ID. Requires authentication.", responses = {
       @ApiResponse(responseCode = "200", description = "User successfully retrieved", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserResponseDto.class))),
@@ -41,6 +47,12 @@ public class UserController {
   @GetMapping("/{id}")
   public ResponseEntity<UserResponseDto> findById(@PathVariable Long id) {
     return ResponseEntity.ok().body(this.userService.findByIdAndReturnDto(id));
+  }
+
+  @GetMapping("/{id}/requested-services")
+  public Page<RequestedServiceResponseDto> findRequestedServiceByUserId(@PathVariable Long id,
+      @ParameterObject Pageable pageable) {
+    return requestedServiceService.findByUserId(id, pageable);
   }
 
   @Operation(summary = "Soft delete user profile", description = "Marks the user profile as deleted (soft delete) using the provided ID. Requires authentication.", responses = {

--- a/src/main/java/br/com/conectabyte/profissu/dtos/response/RequestedServiceResponseDto.java
+++ b/src/main/java/br/com/conectabyte/profissu/dtos/response/RequestedServiceResponseDto.java
@@ -1,9 +1,7 @@
 package br.com.conectabyte.profissu.dtos.response;
 
-import java.util.List;
-
 import br.com.conectabyte.profissu.enums.RequestedServiceStatusEnum;
 
 public record RequestedServiceResponseDto(Long id, String title, String description, RequestedServiceStatusEnum status,
-                AddressResponseDto address, UserResponseDto user, List<ConversationResponseDto> conversations) {
+    AddressResponseDto address, UserResponseDto user) {
 }

--- a/src/main/java/br/com/conectabyte/profissu/mappers/RequestedServiceMapper.java
+++ b/src/main/java/br/com/conectabyte/profissu/mappers/RequestedServiceMapper.java
@@ -26,7 +26,7 @@ public interface RequestedServiceMapper {
   RequestedServiceResponseDto requestedServiceToRequestedServiceResponseDto(
       RequestedService requestedServiceRequestDto);
 
-  default Page<RequestedServiceResponseDto> RequestedServicePageToRequestedServiceResponseDtoPage(
+  default Page<RequestedServiceResponseDto> requestedServicePageToRequestedServiceResponseDtoPage(
       Page<RequestedService> requestedServicePage) {
     final var requestedServiceResponseDtoPageContent = requestedServicePage.getContent().stream()
         .map(this::requestedServiceToRequestedServiceResponseDto)

--- a/src/main/java/br/com/conectabyte/profissu/repositories/ConversationRepository.java
+++ b/src/main/java/br/com/conectabyte/profissu/repositories/ConversationRepository.java
@@ -1,0 +1,8 @@
+package br.com.conectabyte.profissu.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import br.com.conectabyte.profissu.entities.Conversation;
+
+public interface ConversationRepository extends JpaRepository<Conversation, Long> {
+}

--- a/src/main/java/br/com/conectabyte/profissu/repositories/RequestedServiceRepository.java
+++ b/src/main/java/br/com/conectabyte/profissu/repositories/RequestedServiceRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import br.com.conectabyte.profissu.entities.RequestedService;
 
@@ -13,5 +14,19 @@ public interface RequestedServiceRepository extends JpaRepository<RequestedServi
         WHERE rs.status = 'PENDING'
         AND rs.deletedAt IS NULL
       """)
-  Page<RequestedService> findAvailableServiceRequestsByPage(Pageable pageable);
+  Page<RequestedService> findAvailableServiceRequests(Pageable pageable);
+
+  @Query("""
+      FROM RequestedService rs
+        WHERE (
+          rs.user.id = :userId
+          OR EXISTS (
+            FROM rs.conversations c
+              WHERE c.serviceProvider.id = :userId
+              AND c.offerStatus = 'ACCEPTED'
+          )
+        )
+        AND rs.deletedAt IS NULL
+      """)
+  Page<RequestedService> findByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/br/com/conectabyte/profissu/services/RequestedServiceService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/RequestedServiceService.java
@@ -38,13 +38,13 @@ public class RequestedServiceService {
   @Transactional
   public Page<RequestedServiceResponseDto> findAvailableServiceRequests(Pageable pageable) {
     final var availableServiceRequests = requestedServiceRepository.findAvailableServiceRequests(pageable);
-    return requestedServiceMapper.RequestedServicePageToRequestedServiceResponseDtoPage(availableServiceRequests);
+    return requestedServiceMapper.requestedServicePageToRequestedServiceResponseDtoPage(availableServiceRequests);
   }
 
   @Transactional
   public Page<RequestedServiceResponseDto> findByUserId(Long userId, Pageable pageable) {
     final var userServiceRequests = requestedServiceRepository.findByUserId(userId, pageable);
-    return requestedServiceMapper.RequestedServicePageToRequestedServiceResponseDtoPage(userServiceRequests);
+    return requestedServiceMapper.requestedServicePageToRequestedServiceResponseDtoPage(userServiceRequests);
   }
 
   @Transactional

--- a/src/main/java/br/com/conectabyte/profissu/services/RequestedServiceService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/RequestedServiceService.java
@@ -36,9 +36,15 @@ public class RequestedServiceService {
   }
 
   @Transactional
-  public Page<RequestedServiceResponseDto> findAvailableServiceRequestsByPage(Pageable pageable) {
-    final var availableServiceRequests = requestedServiceRepository.findAvailableServiceRequestsByPage(pageable);
+  public Page<RequestedServiceResponseDto> findAvailableServiceRequests(Pageable pageable) {
+    final var availableServiceRequests = requestedServiceRepository.findAvailableServiceRequests(pageable);
     return requestedServiceMapper.RequestedServicePageToRequestedServiceResponseDtoPage(availableServiceRequests);
+  }
+
+  @Transactional
+  public Page<RequestedServiceResponseDto> findByUserId(Long userId, Pageable pageable) {
+    final var userServiceRequests = requestedServiceRepository.findByUserId(userId, pageable);
+    return requestedServiceMapper.RequestedServicePageToRequestedServiceResponseDtoPage(userServiceRequests);
   }
 
   @Transactional

--- a/src/test/java/br/com/conectabyte/profissu/controllers/RequestedServiceControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/RequestedServiceControllerTest.java
@@ -52,15 +52,15 @@ class RequestedServiceControllerTest {
 
   @Test
   @WithMockUser
-  void shouldFindByPage() throws Exception {
+  void shouldFindAvailableServiceRequestsWhenSuccessfully() throws Exception {
     final var user = UserUtils.create();
     final var address = AddressUtils.create(user);
     final var addressResponseDto = AddressMapper.INSTANCE.addressToAddressResponseDto(address);
     final var userResponseDto = UserMapper.INSTANCE.userToUserResponseDto(user);
     final var expectedPage = new PageImpl<>(List.of(new RequestedServiceResponseDto(1L, "Title",
-        "Description", RequestedServiceStatusEnum.PENDING, addressResponseDto, userResponseDto, null)));
+        "Description", RequestedServiceStatusEnum.PENDING, addressResponseDto, userResponseDto)));
 
-    when(requestedServiceService.findAvailableServiceRequestsByPage(any(Pageable.class))).thenReturn(expectedPage);
+    when(requestedServiceService.findAvailableServiceRequests(any(Pageable.class))).thenReturn(expectedPage);
 
     mockMvc.perform(get("/requested-services")
         .param("page", "0")
@@ -79,7 +79,7 @@ class RequestedServiceControllerTest {
     final var addressResponseDto = AddressMapper.INSTANCE.addressToAddressResponseDto(address);
     final var requestedServiceRequestDto = new RequestedServiceRequestDto("Title", "Description", addressRequestDto);
     final var RequestedServiceResponseDto = new RequestedServiceResponseDto(1L, "Title", "Description",
-        RequestedServiceStatusEnum.PENDING, addressResponseDto, null, null);
+        RequestedServiceStatusEnum.PENDING, addressResponseDto, null);
 
     when(securityService.isOwner(any())).thenReturn(true);
     when(requestedServiceService.register(any(), any())).thenReturn(RequestedServiceResponseDto);
@@ -150,7 +150,7 @@ class RequestedServiceControllerTest {
     final var addressResponseDto = AddressMapper.INSTANCE.addressToAddressResponseDto(address);
     final var userResponseDto = UserMapper.INSTANCE.userToUserResponseDto(user);
     final var requestedServiceResponseDto = new RequestedServiceResponseDto(serviceId, "Title", "Description",
-        RequestedServiceStatusEnum.CANCELLED, addressResponseDto, userResponseDto, null);
+        RequestedServiceStatusEnum.CANCELLED, addressResponseDto, userResponseDto);
 
     when(securityService.isOwnerOfRequestedService(any())).thenReturn(true);
     when(requestedServiceService.cancel(any())).thenReturn(requestedServiceResponseDto);

--- a/src/test/java/br/com/conectabyte/profissu/controllers/UserControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/UserControllerTest.java
@@ -33,6 +33,7 @@ import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
 import br.com.conectabyte.profissu.mappers.AddressMapper;
 import br.com.conectabyte.profissu.mappers.ContactMapper;
 import br.com.conectabyte.profissu.mappers.UserMapper;
+import br.com.conectabyte.profissu.services.RequestedServiceService;
 import br.com.conectabyte.profissu.services.SecurityService;
 import br.com.conectabyte.profissu.services.UserService;
 import br.com.conectabyte.profissu.utils.AddressUtils;
@@ -48,6 +49,9 @@ public class UserControllerTest {
 
   @MockBean
   private UserService userService;
+
+  @MockBean
+  private RequestedServiceService requestedServiceService;
 
   @MockBean
   private SecurityService securityService;

--- a/src/test/java/br/com/conectabyte/profissu/controllers/UserControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/UserControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -32,12 +33,14 @@ import br.com.conectabyte.profissu.enums.GenderEnum;
 import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
 import br.com.conectabyte.profissu.mappers.AddressMapper;
 import br.com.conectabyte.profissu.mappers.ContactMapper;
+import br.com.conectabyte.profissu.mappers.RequestedServiceMapper;
 import br.com.conectabyte.profissu.mappers.UserMapper;
 import br.com.conectabyte.profissu.services.RequestedServiceService;
 import br.com.conectabyte.profissu.services.SecurityService;
 import br.com.conectabyte.profissu.services.UserService;
 import br.com.conectabyte.profissu.utils.AddressUtils;
 import br.com.conectabyte.profissu.utils.ContactUtils;
+import br.com.conectabyte.profissu.utils.RequestedServiceUtils;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
 @WebMvcTest({ UserController.class, SecurityService.class })
@@ -280,5 +283,24 @@ public class UserControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(validProfileRequestDto)))
         .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser
+  void shouldFindRequestedServicesByUserId() throws Exception {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+    final var requestedService = RequestedServiceUtils.create(user, address);
+    final var requestedServiceResponseDto = RequestedServiceMapper.INSTANCE
+        .requestedServiceToRequestedServiceResponseDto(requestedService);
+    final var page = new PageImpl<>(List.of(requestedServiceResponseDto));
+
+    when(requestedServiceService.findByUserId(any(), any())).thenReturn(page);
+
+    mockMvc.perform(get("/users/1/requested-services")
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content[0]").exists());
   }
 }

--- a/src/test/java/br/com/conectabyte/profissu/repositories/RequestedServiceRepositoryTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/repositories/RequestedServiceRepositoryTest.java
@@ -42,7 +42,7 @@ public class RequestedServiceRepositoryTest {
 
     requestedServiceRepository.save(requestedService);
 
-    final var requestedServicePage = requestedServiceRepository.findAvailableServiceRequestsByPage(Pageable.ofSize(10));
+    final var requestedServicePage = requestedServiceRepository.findAvailableServiceRequests(Pageable.ofSize(10));
 
     assertTrue(requestedServicePage.getTotalElements() > 0);
   }
@@ -61,7 +61,7 @@ public class RequestedServiceRepositoryTest {
     requestedService.setStatus(RequestedServiceStatusEnum.DONE);
     requestedServiceRepository.save(requestedService);
 
-    final var requestedServicePage = requestedServiceRepository.findAvailableServiceRequestsByPage(Pageable.ofSize(10));
+    final var requestedServicePage = requestedServiceRepository.findAvailableServiceRequests(Pageable.ofSize(10));
 
     assertEquals(requestedServicePage.getTotalElements(), 0);
   }
@@ -80,7 +80,7 @@ public class RequestedServiceRepositoryTest {
     requestedService.setDeletedAt(LocalDateTime.now());
     requestedServiceRepository.save(requestedService);
 
-    final var requestedServicePage = requestedServiceRepository.findAvailableServiceRequestsByPage(Pageable.ofSize(10));
+    final var requestedServicePage = requestedServiceRepository.findAvailableServiceRequests(Pageable.ofSize(10));
 
     assertEquals(requestedServicePage.getTotalElements(), 0);
   }

--- a/src/test/java/br/com/conectabyte/profissu/repositories/RequestedServiceRepositoryTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/repositories/RequestedServiceRepositoryTest.java
@@ -13,9 +13,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 
+import br.com.conectabyte.profissu.enums.OfferStatusEnum;
 import br.com.conectabyte.profissu.enums.RequestedServiceStatusEnum;
 import br.com.conectabyte.profissu.utils.AddressUtils;
 import br.com.conectabyte.profissu.utils.ContactUtils;
+import br.com.conectabyte.profissu.utils.ConversationUtils;
 import br.com.conectabyte.profissu.utils.RequestedServiceUtils;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
@@ -28,6 +30,9 @@ public class RequestedServiceRepositoryTest {
 
   @Autowired
   private UserRepository userRepository;
+
+  @Autowired
+  private ConversationRepository conversationRepository;
 
   @Test
   public void shouldReturnRequestedServicePageWhenHavePandingRequestServices() {
@@ -83,5 +88,86 @@ public class RequestedServiceRepositoryTest {
     final var requestedServicePage = requestedServiceRepository.findAvailableServiceRequests(Pageable.ofSize(10));
 
     assertEquals(requestedServicePage.getTotalElements(), 0);
+  }
+
+  @Test
+  public void shouldFindRequestedServicesByUser() {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+
+    user.setAddresses(List.of(address));
+
+    final var savedUser = userRepository.save(user);
+    final var requestedService = RequestedServiceUtils.create(savedUser, savedUser.getAddresses().get(0));
+
+    requestedServiceRepository.save(requestedService);
+
+    final var requestedServicePage = requestedServiceRepository.findByUserId(savedUser.getId(), Pageable.ofSize(10));
+
+    assertEquals(1, requestedServicePage.getTotalElements());
+    assertEquals(savedUser.getId(), requestedServicePage.getContent().get(0).getUser().getId());
+  }
+
+  @Test
+  public void shouldFindRequestedServicesByServiceProviderInAcceptedConversation() {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+
+    user.setAddresses(List.of(address));
+
+    final var savedUser = userRepository.save(user);
+    final var serviceProvider = UserUtils.create();
+    final var requestedService = RequestedServiceUtils.create(savedUser, savedUser.getAddresses().get(0));
+    final var savedServiceProvider = userRepository.save(serviceProvider);
+    final var savedRequestedService = requestedServiceRepository.save(requestedService);
+    final var conversation = ConversationUtils.create(savedUser, savedServiceProvider, savedRequestedService, List.of());
+
+    conversation.setOfferStatus(OfferStatusEnum.ACCEPTED);
+    conversationRepository.save(conversation);
+
+    final var requestedServicePage = requestedServiceRepository.findByUserId(savedServiceProvider.getId(), Pageable.ofSize(10));
+
+    assertEquals(1, requestedServicePage.getTotalElements());
+    assertEquals(savedRequestedService.getId(), requestedServicePage.getContent().get(0).getId());
+  }
+
+  @Test
+  public void shouldNotFindRequestedServicesByServiceProviderInPendingConversation() {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+
+    user.setAddresses(List.of(address));
+
+    final var savedUser = userRepository.save(user);
+    final var serviceProvider = UserUtils.create();
+    final var requestedService = RequestedServiceUtils.create(savedUser, savedUser.getAddresses().get(0));
+    final var savedServiceProvider = userRepository.save(serviceProvider);
+    final var savedRequestedService = requestedServiceRepository.save(requestedService);
+    final var conversation = ConversationUtils.create(savedUser, savedServiceProvider, savedRequestedService, List.of());
+
+    conversation.setOfferStatus(OfferStatusEnum.PENDING);
+    conversationRepository.save(conversation);
+
+    final var requestedServicePage = requestedServiceRepository.findByUserId(savedServiceProvider.getId(), Pageable.ofSize(10));
+
+    assertEquals(0, requestedServicePage.getTotalElements());
+  }
+
+  @Test
+  public void shouldNotFindDeletedRequestedServices() {
+    final var user = UserUtils.create();
+    final var address = AddressUtils.create(user);
+
+    user.setAddresses(List.of(address));
+
+    final var savedUser = userRepository.save(user);
+    final var requestedService = RequestedServiceUtils.create(savedUser, savedUser.getAddresses().get(0));
+
+    requestedService.setDeletedAt(LocalDateTime.now());
+    requestedServiceRepository.save(requestedService);
+
+    final var result = requestedServiceRepository.findByUserId(user.getId(), Pageable.ofSize(10));
+
+    assertEquals(0, result.getTotalElements());
   }
 }

--- a/src/test/java/br/com/conectabyte/profissu/services/RequestedServiceServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/RequestedServiceServiceTest.java
@@ -50,7 +50,7 @@ class RequestedServiceServiceTest {
   private RequestedServiceService requestedServiceService;
 
   @Test
-  void shouldFindByPage() {
+  void shouldFindAvailableServiceRequestsWhenSuccessfully() {
     final var pageable = PageRequest.of(0, 10);
     final var requestedService = new RequestedService();
     final var user = UserUtils.create();
@@ -59,9 +59,9 @@ class RequestedServiceServiceTest {
 
     final var requestedServicePage = new PageImpl<>(List.of(requestedService));
 
-    when(requestedServiceRepository.findAvailableServiceRequestsByPage(pageable)).thenReturn(requestedServicePage);
+    when(requestedServiceRepository.findAvailableServiceRequests(pageable)).thenReturn(requestedServicePage);
 
-    Page<RequestedServiceResponseDto> result = requestedServiceService.findAvailableServiceRequestsByPage(pageable);
+    Page<RequestedServiceResponseDto> result = requestedServiceService.findAvailableServiceRequests(pageable);
 
     assertNotNull(result);
     assertEquals(1, result.getTotalElements());
@@ -103,9 +103,9 @@ class RequestedServiceServiceTest {
     final var pageable = PageRequest.of(0, 10);
     final Page<RequestedService> emptyPage = Page.empty();
 
-    when(requestedServiceRepository.findAvailableServiceRequestsByPage(pageable)).thenReturn(emptyPage);
+    when(requestedServiceRepository.findAvailableServiceRequests(pageable)).thenReturn(emptyPage);
 
-    final var result = requestedServiceService.findAvailableServiceRequestsByPage(pageable);
+    final var result = requestedServiceService.findAvailableServiceRequests(pageable);
 
     assertNotNull(result);
     assertEquals(0, result.getTotalElements());


### PR DESCRIPTION
### Description
This pull request introduces a new endpoint to retrieve a user's service history, including both services they have requested and services they have provided.

### Main Changes
- **Implement service request user history:** Adds logic to fetch and display a user’s service history, including both requests they created and accepted conversations where they act as a service provider.
- **Add tests for service request user history:** Includes test coverage for various scenarios, ensuring correct history retrieval for both requesters and service providers.
- **Add documentation for service request user history:** Updates the system documentation with details about the new endpoint, including a description, input parameters, expected responses, and usage examples.