### PR TITLE
Create endpoint to accept or reject an offer

### DIFF
--- a/src/main/java/br/com/conectabyte/profissu/controllers/ConversationController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/ConversationController.java
@@ -55,12 +55,21 @@ public class ConversationController {
   @PreAuthorize("@securityConversationService.ownershipCheck(#id) || @securityService.isAdmin()")
   @PatchMapping("/{id}")
   public ResponseEntity<ConversationResponseDto> cancel(@PathVariable Long id) {
-    return ResponseEntity.status(HttpStatus.OK).body(this.conversationService.cancel(id));
+    return ResponseEntity.ok(this.conversationService.cancel(id));
   }
 
+  @Operation(summary = "Accept or reject a service offer", description = "Allows the user who owns the requested service or an admin to accept or reject a pending offer.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Offer successfully updated", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ConversationResponseDto.class))),
+      @ApiResponse(responseCode = "400", description = "Invalid request format or offer status", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "401", description = "Invalid or missing authentication credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "404", description = "Conversation not found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+  })
   @PreAuthorize("@securityConversationService.requestedServiceOwner(#id) || @securityService.isAdmin()")
   @PatchMapping("/{id}/{offerStatus}")
-  public ResponseEntity<ConversationResponseDto> acceptOrRejectOffer(@PathVariable Long id, @PathVariable OfferStatusEnum offerStatus) {
-    return ResponseEntity.status(HttpStatus.OK).body(this.conversationService.acceptOrRejectOffer(id, offerStatus));
+  public ResponseEntity<ConversationResponseDto> acceptOrRejectOffer(@PathVariable Long id,
+      @PathVariable OfferStatusEnum offerStatus) {
+    return ResponseEntity.ok(this.conversationService.acceptOrRejectOffer(id, offerStatus));
   }
 }

--- a/src/main/java/br/com/conectabyte/profissu/controllers/ConversationController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/ConversationController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import br.com.conectabyte.profissu.dtos.request.ConversationRequestDto;
 import br.com.conectabyte.profissu.dtos.response.ConversationResponseDto;
 import br.com.conectabyte.profissu.dtos.response.ExceptionDto;
+import br.com.conectabyte.profissu.enums.OfferStatusEnum;
 import br.com.conectabyte.profissu.services.ConversationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -55,5 +56,11 @@ public class ConversationController {
   @PatchMapping("/{id}")
   public ResponseEntity<ConversationResponseDto> cancel(@PathVariable Long id) {
     return ResponseEntity.status(HttpStatus.OK).body(this.conversationService.cancel(id));
+  }
+
+  @PreAuthorize("@securityConversationService.requestedServiceOwner(#id) || @securityService.isAdmin()")
+  @PatchMapping("/{id}/{offerStatus}")
+  public ResponseEntity<ConversationResponseDto> acceptOrRejectOffer(@PathVariable Long id, @PathVariable OfferStatusEnum offerStatus) {
+    return ResponseEntity.status(HttpStatus.OK).body(this.conversationService.acceptOrRejectOffer(id, offerStatus));
   }
 }

--- a/src/main/java/br/com/conectabyte/profissu/services/security/SecurityConversationService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/security/SecurityConversationService.java
@@ -20,4 +20,13 @@ public class SecurityConversationService implements OwnerCheck {
       return false;
     }
   }
+
+  public boolean requestedServiceOwner(Long id) {
+    try {
+      final var conversation = conversationService.findById(id);
+      return securityService.isOwner(conversation.getRequester().getId());
+    } catch (Exception e) {
+      return false;
+    }
+  }
 }

--- a/src/test/java/br/com/conectabyte/profissu/controllers/ConversationControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/ConversationControllerTest.java
@@ -93,4 +93,42 @@ class ConversationControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.offerStatus").value(OfferStatusEnum.PENDING.toString()));
   }
+
+  @Test
+  @WithMockUser
+  void shouldAcceptAConversation() throws Exception {
+    final var user = UserUtils.create();
+    final var requestedService = RequestedServiceUtils.create(user, AddressUtils.create(user));
+    final var conversation = ConversationUtils.create(user, UserUtils.create(), requestedService, List.of());
+
+    conversation.setOfferStatus(OfferStatusEnum.ACCEPTED);
+
+    final var conversationResponseDto = ConversationMapper.INSTANCE.conversationToConversationResponseDto(conversation);
+
+    when(conversationService.acceptOrRejectOffer(any(), any())).thenReturn(conversationResponseDto);
+    when(securityConversationService.requestedServiceOwner(any())).thenReturn(true);
+
+    mockMvc.perform(patch("/conversations/1/ACCEPTED"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.offerStatus").value(OfferStatusEnum.ACCEPTED.toString()));
+  }
+
+  @Test
+  @WithMockUser
+  void shouldRejectAConversation() throws Exception {
+    final var user = UserUtils.create();
+    final var requestedService = RequestedServiceUtils.create(user, AddressUtils.create(user));
+    final var conversation = ConversationUtils.create(user, UserUtils.create(), requestedService, List.of());
+
+    conversation.setOfferStatus(OfferStatusEnum.REJECTED);
+
+    final var conversationResponseDto = ConversationMapper.INSTANCE.conversationToConversationResponseDto(conversation);
+
+    when(conversationService.acceptOrRejectOffer(any(), any())).thenReturn(conversationResponseDto);
+    when(securityConversationService.requestedServiceOwner(any())).thenReturn(true);
+
+    mockMvc.perform(patch("/conversations/1/REJECTED"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.offerStatus").value(OfferStatusEnum.REJECTED.toString()));
+  }
 }

--- a/src/test/java/br/com/conectabyte/profissu/services/ConversationServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/ConversationServiceTest.java
@@ -166,8 +166,7 @@ class ConversationServiceTest {
     conversation.setId(1L);
     serviceProvider.setConversationsAsAServiceProvider(List.of(conversation));
 
-    when(jwtService.getClaims()).thenReturn(Optional.of(new HashMap<>(Map.of("sub", "1"))));
-    when(userService.findById(any())).thenReturn(serviceProvider);
+    when(conversationRepository.findById(any())).thenReturn(Optional.of(conversation));
     when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
     final var response = conversationService.cancel(1L);
@@ -182,8 +181,7 @@ class ConversationServiceTest {
 
     serviceProvider.setConversationsAsAServiceProvider(List.of());
 
-    when(jwtService.getClaims()).thenReturn(Optional.of(new HashMap<>(Map.of("sub", "1"))));
-    when(userService.findById(any())).thenReturn(serviceProvider);
+    when(conversationRepository.findById(any())).thenReturn(Optional.empty());
 
     ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
         () -> conversationService.cancel(1L));
@@ -199,11 +197,8 @@ class ConversationServiceTest {
     final var conversation = ConversationUtils.create(requester, serviceProvider, requestedService, List.of());
 
     conversation.setOfferStatus(OfferStatusEnum.CANCELLED);
-    conversation.setId(1L);
-    serviceProvider.setConversationsAsAServiceProvider(List.of(conversation));
 
-    when(jwtService.getClaims()).thenReturn(Optional.of(new HashMap<>(Map.of("sub", "1"))));
-    when(userService.findById(1L)).thenReturn(serviceProvider);
+    when(conversationRepository.findById(any())).thenReturn(Optional.of(conversation));
 
     ValidationException exception = assertThrows(ValidationException.class,
         () -> conversationService.cancel(1L));

--- a/src/test/java/br/com/conectabyte/profissu/services/security/SecurityAddressServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/security/SecurityAddressServiceTest.java
@@ -32,7 +32,6 @@ public class SecurityAddressServiceTest {
     final var user = UserUtils.create();
     final var address = AddressUtils.create(user);
 
-    user.setId(0L);
     when(addressService.findById(any())).thenReturn(address);
     when(securityService.isOwner(any())).thenReturn(true);
 

--- a/src/test/java/br/com/conectabyte/profissu/services/security/SecurityContactServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/security/SecurityContactServiceTest.java
@@ -36,7 +36,7 @@ public class SecurityContactServiceTest {
     when(contactService.findById(any())).thenReturn(contact);
     when(securityService.isOwner(any())).thenReturn(true);
 
-    boolean isOwner = securityContactService.ownershipCheck(user.getId());
+    final var isOwner = securityContactService.ownershipCheck(user.getId());
 
     assertTrue(isOwner);
   }
@@ -52,7 +52,7 @@ public class SecurityContactServiceTest {
 
     when(contactService.findById(any())).thenReturn(contact);
 
-    boolean isOwner = securityContactService.ownershipCheck(resourceUserId);
+    final var isOwner = securityContactService.ownershipCheck(resourceUserId);
 
     assertFalse(isOwner);
   }

--- a/src/test/java/br/com/conectabyte/profissu/services/security/SecurityConversationServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/security/SecurityConversationServiceTest.java
@@ -32,42 +32,73 @@ public class SecurityConversationServiceTest {
   private SecurityConversationService securityConversationService;
 
   @Test
-  void shouldReturnTrueWhenUserIsOwnerOfContact() {
+  void shouldReturnTrueWhenUserIsOwnerOfConversation() {
     final var user = UserUtils.create();
     final var requestedService = RequestedServiceUtils.create(user, AddressUtils.create(user));
     final var conversation = ConversationUtils.create(user, UserUtils.create(), requestedService, List.of());
 
-    user.setId(0L);
     when(conversationService.findById(any())).thenReturn(conversation);
     when(securityService.isOwner(any())).thenReturn(true);
 
-    boolean isOwner = securityConversationService.ownershipCheck(user.getId());
+    final var isOwner = securityConversationService.ownershipCheck(user.getId());
 
     assertTrue(isOwner);
   }
 
   @Test
-  void shouldReturnFalseWhenUserIsNotOwnerOfContact() {
+  void shouldReturnFalseWhenUserIsNotOwnerOfConversation() {
     final var user = UserUtils.create();
     final var requestedService = RequestedServiceUtils.create(user, AddressUtils.create(user));
     final var conversation = ConversationUtils.create(user, UserUtils.create(), requestedService, List.of());
 
-    user.setId(0L);
-
-    final var resourceUserId = user.getId() + 1;
-
     when(conversationService.findById(any())).thenReturn(conversation);
 
-    boolean isOwner = securityConversationService.ownershipCheck(resourceUserId);
+    final var isOwner = securityConversationService.ownershipCheck(0L);
 
     assertFalse(isOwner);
   }
 
   @Test
-  void shouldReturnFalseWhenContactNotFound() {
-    when(conversationService.findById(any())).thenThrow(new ResourceNotFoundException("Contact not found"));
+  void shouldReturnFalseWhenConversationNotFound() {
+    when(conversationService.findById(any())).thenThrow(new ResourceNotFoundException("Conversation not found"));
 
     final var isOwner = securityConversationService.ownershipCheck(any());
+
+    assertFalse(isOwner);
+  }
+
+  @Test
+  void shouldReturnTrueWhenUserIsOwnerOfRequestedService() {
+    final var user = UserUtils.create();
+    final var requestedService = RequestedServiceUtils.create(user, AddressUtils.create(user));
+    final var conversation = ConversationUtils.create(user, UserUtils.create(), requestedService, List.of());
+
+    when(conversationService.findById(any())).thenReturn(conversation);
+    when(securityService.isOwner(any())).thenReturn(true);
+
+    final var isOwner = securityConversationService.requestedServiceOwner(conversation.getId());
+
+    assertTrue(isOwner);
+  }
+
+  @Test
+  void shouldReturnFalseWhenUserIsNotOwnerOfRequestedService() {
+    final var user = UserUtils.create();
+    final var requestedService = RequestedServiceUtils.create(user, AddressUtils.create(user));
+    final var conversation = ConversationUtils.create(user, UserUtils.create(), requestedService, List.of());
+
+    when(conversationService.findById(any())).thenReturn(conversation);
+
+    final var isOwner = securityConversationService.requestedServiceOwner(0L);
+
+    assertFalse(isOwner);
+  }
+
+  @Test
+  void shouldReturnFalseWhenConversationNotFounda() {
+    when(conversationService.findById(any())).thenThrow(new ResourceNotFoundException("Conversation not found"));
+
+    final var isOwner = securityConversationService.requestedServiceOwner(any());
 
     assertFalse(isOwner);
   }

--- a/src/test/java/br/com/conectabyte/profissu/services/security/SecurityRequestedServiceServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/security/SecurityRequestedServiceServiceTest.java
@@ -34,7 +34,6 @@ public class SecurityRequestedServiceServiceTest {
     final var address = AddressUtils.create(user);
     final var requestedService = RequestedServiceUtils.create(user, address);
 
-    user.setId(0L);
     when(requestedServiceService.findById(any())).thenReturn(requestedService);
     when(mockedSecurityService.isOwner(any())).thenReturn(true);
 


### PR DESCRIPTION
### Description
This PR implements the accept/reject offer functionality, including API endpoints, tests and documentation. It ensures that only valid status transitions are allowed and properly handles edge cases.

### Main Changes
- **Created API endpoints**: Added `acceptOrRejectOffer` endpoint to handle offer acceptance and rejection.
- **Added tests**: Covered scenarios where a conversation is accepted, rejected, or has an invalid status.
- **Documented API**: Added OpenAPI documentation for the new endpoint, including possible responses.