### PR TITLE
Create endpoint to send messages

### DIFF
--- a/src/main/java/br/com/conectabyte/profissu/config/WebSocketConfig.java
+++ b/src/main/java/br/com/conectabyte/profissu/config/WebSocketConfig.java
@@ -1,0 +1,36 @@
+package br.com.conectabyte.profissu.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import br.com.conectabyte.profissu.config.interceptors.JwtAuthChannelInterceptor;
+import br.com.conectabyte.profissu.repositories.ConversationRepository;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+  private final JwtDecoder jwtDecoder;
+  private final ConversationRepository conversationRepository;
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+  }
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    registry.enableSimpleBroker("/topic");
+  }
+
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    registration.interceptors(new JwtAuthChannelInterceptor(jwtDecoder, conversationRepository));
+  }
+}

--- a/src/main/java/br/com/conectabyte/profissu/config/interceptors/JwtAuthChannelInterceptor.java
+++ b/src/main/java/br/com/conectabyte/profissu/config/interceptors/JwtAuthChannelInterceptor.java
@@ -30,6 +30,10 @@ public class JwtAuthChannelInterceptor implements ChannelInterceptor {
     final var token = accessor.getFirstNativeHeader("token");
     final var decodedToken = validateToken(token);
 
+    if (decodedToken == null) {
+      return null;
+    }
+
     if (StompCommand.SUBSCRIBE.equals(accessor.getCommand()) || StompCommand.SEND.equals(accessor.getCommand())) {
       final var destination = accessor.getDestination();
       final var conversationId = extractConversationId(destination);
@@ -38,7 +42,7 @@ public class JwtAuthChannelInterceptor implements ChannelInterceptor {
           .map(Long::valueOf)
           .orElseThrow();
 
-      if (decodedToken == null || conversationId == null) {
+      if (conversationId == null) {
         return null;
       }
 

--- a/src/main/java/br/com/conectabyte/profissu/config/interceptors/JwtAuthChannelInterceptor.java
+++ b/src/main/java/br/com/conectabyte/profissu/config/interceptors/JwtAuthChannelInterceptor.java
@@ -1,0 +1,85 @@
+package br.com.conectabyte.profissu.config.interceptors;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.stereotype.Component;
+
+import br.com.conectabyte.profissu.exceptions.ValidationException;
+import br.com.conectabyte.profissu.repositories.ConversationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthChannelInterceptor implements ChannelInterceptor {
+  private final JwtDecoder jwtDecoder;
+  private final ConversationRepository conversationRepository;
+
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+    final var accessor = StompHeaderAccessor.wrap(message);
+    final var token = accessor.getFirstNativeHeader("token");
+    final var decodedToken = validateToken(token);
+
+    if (StompCommand.SUBSCRIBE.equals(accessor.getCommand()) || StompCommand.SEND.equals(accessor.getCommand())) {
+      final var destination = accessor.getDestination();
+      final var conversationId = extractConversationId(destination);
+      final var userId = Optional.ofNullable(decodedToken.getClaims().get("sub"))
+          .map(Object::toString)
+          .map(Long::valueOf)
+          .orElseThrow();
+
+      if (decodedToken == null || conversationId == null) {
+        return null;
+      }
+
+      if (!conversationRepository.isUserInConversation(userId, conversationId)) {
+        log.warn("User is not authorized for this subscription.");
+
+        return null;
+      }
+    }
+
+    return message;
+  }
+
+  private Jwt validateToken(String token) {
+    try {
+      if (token == null || token.isBlank()) {
+        throw new ValidationException("JWT token is required for this action.");
+      }
+
+      if (token.startsWith("Bearer ")) {
+        token = token.substring(7);
+      }
+
+      return jwtDecoder.decode(token);
+    } catch (Exception e) {
+      log.warn("Invalid JWT token: " + e.getMessage());
+
+      return null;
+    }
+  }
+
+  private Long extractConversationId(String destination) {
+    final var pattern = Pattern.compile("^/topic/conversations/(\\d+)/messages$");
+    final var matcher = pattern.matcher(destination);
+
+    if (matcher.matches()) {
+      return Long.valueOf(matcher.group(1));
+    }
+
+    log.warn("Destination not found: " + destination);
+
+    return null;
+  }
+}

--- a/src/main/java/br/com/conectabyte/profissu/controllers/ConversationController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/ConversationController.java
@@ -11,8 +11,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import br.com.conectabyte.profissu.dtos.request.ConversationRequestDto;
+import br.com.conectabyte.profissu.dtos.request.MessageRequestDto;
 import br.com.conectabyte.profissu.dtos.response.ConversationResponseDto;
 import br.com.conectabyte.profissu.dtos.response.ExceptionDto;
+import br.com.conectabyte.profissu.dtos.response.MessageResponseDto;
 import br.com.conectabyte.profissu.enums.OfferStatusEnum;
 import br.com.conectabyte.profissu.services.ConversationService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,6 +44,13 @@ public class ConversationController {
   public ResponseEntity<ConversationResponseDto> start(
       @Valid @RequestBody ConversationRequestDto conversationRequestDto) {
     return ResponseEntity.status(HttpStatus.CREATED).body(this.conversationService.start(conversationRequestDto));
+  }
+
+  @PreAuthorize("@securityConversationService.ownershipCheck(#id) || @securityConversationService.requestedServiceOwner(#id) || @securityService.isAdmin()")
+  @PostMapping("/{id}/messages")
+  public ResponseEntity<MessageResponseDto> sendMessage(@PathVariable Long id,
+      @Valid @RequestBody MessageRequestDto messageRequestDto) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(this.conversationService.sendMessage(id, messageRequestDto));
   }
 
   @Operation(summary = "Cancel a service offer", description = "Allows the user who created the conversation or an admin to cancel an existing offer.")

--- a/src/main/java/br/com/conectabyte/profissu/controllers/ConversationController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/ConversationController.java
@@ -46,6 +46,14 @@ public class ConversationController {
     return ResponseEntity.status(HttpStatus.CREATED).body(this.conversationService.start(conversationRequestDto));
   }
 
+  @Operation(summary = "Send a message in a conversation", description = "Allows the user who is part of the conversation or an admin to send a message within an existing conversation.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "Message successfully sent", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MessageResponseDto.class))),
+      @ApiResponse(responseCode = "400", description = "Invalid request format or missing required fields", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "401", description = "Invalid or missing authentication credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "404", description = "Conversation not found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+  })
   @PreAuthorize("@securityConversationService.ownershipCheck(#id) || @securityConversationService.requestedServiceOwner(#id) || @securityService.isAdmin()")
   @PostMapping("/{id}/messages")
   public ResponseEntity<MessageResponseDto> sendMessage(@PathVariable Long id,

--- a/src/main/java/br/com/conectabyte/profissu/dtos/request/MessageRequestDto.java
+++ b/src/main/java/br/com/conectabyte/profissu/dtos/request/MessageRequestDto.java
@@ -1,0 +1,7 @@
+package br.com.conectabyte.profissu.dtos.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MessageRequestDto(
+  @NotBlank(message = "message: Cannot be null or empty") String message) {
+}

--- a/src/main/java/br/com/conectabyte/profissu/entities/Message.java
+++ b/src/main/java/br/com/conectabyte/profissu/entities/Message.java
@@ -10,16 +10,23 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "messages")
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Message {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Builder.Default
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt = LocalDateTime.now();
 

--- a/src/main/java/br/com/conectabyte/profissu/mappers/MessageMapper.java
+++ b/src/main/java/br/com/conectabyte/profissu/mappers/MessageMapper.java
@@ -1,0 +1,14 @@
+package br.com.conectabyte.profissu.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import br.com.conectabyte.profissu.dtos.response.MessageResponseDto;
+import br.com.conectabyte.profissu.entities.Message;
+
+@Mapper
+public interface MessageMapper {
+  MessageMapper INSTANCE = Mappers.getMapper(MessageMapper.class);
+
+  MessageResponseDto messageToMessageResponseDto(Message message);
+}

--- a/src/main/java/br/com/conectabyte/profissu/properties/Application.java
+++ b/src/main/java/br/com/conectabyte/profissu/properties/Application.java
@@ -1,0 +1,8 @@
+package br.com.conectabyte.profissu.properties;
+
+import lombok.Data;
+
+@Data
+public class Application {
+  private String name;
+}

--- a/src/main/java/br/com/conectabyte/profissu/properties/Jwt.java
+++ b/src/main/java/br/com/conectabyte/profissu/properties/Jwt.java
@@ -3,12 +3,22 @@ package br.com.conectabyte.profissu.properties;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Setter;
 
 @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Jwt {
+  @JsonProperty("expires-in")
   private Long expiresIn;
+
+  @JsonIgnore
   private RSAPublicKey publicKeyLocation;
+
+  @JsonIgnore
   private RSAPrivateKey privateKeyLocation;
 
   public Long getExpiresIn() {

--- a/src/main/java/br/com/conectabyte/profissu/properties/Jwt.java
+++ b/src/main/java/br/com/conectabyte/profissu/properties/Jwt.java
@@ -1,0 +1,25 @@
+package br.com.conectabyte.profissu.properties;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+import lombok.Setter;
+
+@Setter
+public class Jwt {
+  private Long expiresIn;
+  private RSAPublicKey publicKeyLocation;
+  private RSAPrivateKey privateKeyLocation;
+
+  public Long getExpiresIn() {
+    return expiresIn;
+  }
+
+  public RSAPublicKey getPublicKey() {
+    return publicKeyLocation;
+  }
+
+  public RSAPrivateKey getPrivateKey() {
+    return privateKeyLocation;
+  }
+}

--- a/src/main/java/br/com/conectabyte/profissu/properties/Profissu.java
+++ b/src/main/java/br/com/conectabyte/profissu/properties/Profissu.java
@@ -1,0 +1,12 @@
+package br.com.conectabyte.profissu.properties;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class Profissu {
+    private Jwt jwt = new Jwt();
+    private String url;
+    private List<String> allowedOrigins;
+}

--- a/src/main/java/br/com/conectabyte/profissu/properties/Profissu.java
+++ b/src/main/java/br/com/conectabyte/profissu/properties/Profissu.java
@@ -2,9 +2,12 @@ package br.com.conectabyte.profissu.properties;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Data;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Profissu {
     private Jwt jwt = new Jwt();
     private String url;

--- a/src/main/java/br/com/conectabyte/profissu/properties/ProfissuProperties.java
+++ b/src/main/java/br/com/conectabyte/profissu/properties/ProfissuProperties.java
@@ -1,0 +1,14 @@
+package br.com.conectabyte.profissu.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+@Data
+@Component
+@ConfigurationProperties
+public class ProfissuProperties {
+    private Spring spring = new Spring();
+    private Profissu profissu = new Profissu();
+}

--- a/src/main/java/br/com/conectabyte/profissu/properties/ProfissuProperties.java
+++ b/src/main/java/br/com/conectabyte/profissu/properties/ProfissuProperties.java
@@ -3,11 +3,14 @@ package br.com.conectabyte.profissu.properties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Data;
 
 @Data
 @Component
 @ConfigurationProperties
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ProfissuProperties {
     private Spring spring = new Spring();
     private Profissu profissu = new Profissu();

--- a/src/main/java/br/com/conectabyte/profissu/properties/Spring.java
+++ b/src/main/java/br/com/conectabyte/profissu/properties/Spring.java
@@ -1,0 +1,8 @@
+package br.com.conectabyte.profissu.properties;
+
+import lombok.Data;
+
+@Data
+public class Spring {
+  private Application application = new Application();
+}

--- a/src/main/java/br/com/conectabyte/profissu/properties/Spring.java
+++ b/src/main/java/br/com/conectabyte/profissu/properties/Spring.java
@@ -1,8 +1,11 @@
 package br.com.conectabyte.profissu.properties;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Data;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Spring {
   private Application application = new Application();
 }

--- a/src/main/java/br/com/conectabyte/profissu/repositories/ConversationRepository.java
+++ b/src/main/java/br/com/conectabyte/profissu/repositories/ConversationRepository.java
@@ -4,10 +4,20 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import br.com.conectabyte.profissu.entities.Conversation;
 
 public interface ConversationRepository extends JpaRepository<Conversation, Long> {
   @Query("FROM Conversation c WHERE c.requester.id = :userId")
   Page<Conversation> findByUserId(Long userId, Pageable pageable);
+
+  @Query("""
+      SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END
+      FROM Conversation c
+      WHERE c.id = :conversationId AND (
+        c.requester.id = :userId OR c.serviceProvider.id = :userId
+      )
+      """)
+  boolean isUserInConversation(@Param("userId") Long userId, @Param("conversationId") Long conversationId);
 }

--- a/src/main/java/br/com/conectabyte/profissu/repositories/MessageRepository.java
+++ b/src/main/java/br/com/conectabyte/profissu/repositories/MessageRepository.java
@@ -1,0 +1,8 @@
+package br.com.conectabyte.profissu.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import br.com.conectabyte.profissu.entities.Message;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/src/main/java/br/com/conectabyte/profissu/services/EmailService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/EmailService.java
@@ -2,7 +2,6 @@ package br.com.conectabyte.profissu.services;
 
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
@@ -10,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
+import br.com.conectabyte.profissu.properties.ProfissuProperties;
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,9 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class EmailService {
   private final JavaMailSender javaMailSender;
   private final TemplateEngine templateEngine;
-
-  @Value("${profissu.url}")
-  private String profissuUrl;
+  private final ProfissuProperties profissuProperties;
 
   private final String LOGO_PATH = "/images/profissu.jpeg";
 
@@ -48,7 +46,7 @@ public class EmailService {
 
   public void sendPasswordRecoveryEmail(String email, String code) {
     final var variables = Map.of(
-        "profissuLogoUrl", profissuUrl + LOGO_PATH,
+        "profissuLogoUrl", profissuProperties.getProfissu().getUrl() + LOGO_PATH,
         "code", code,
         "emailTitle", "Password Recovery",
         "emailMessage",
@@ -66,7 +64,7 @@ public class EmailService {
 
   public void sendSignUpConfirmation(String email, String code) {
     final var variables = Map.of(
-        "profissuLogoUrl", profissuUrl + LOGO_PATH,
+        "profissuLogoUrl", profissuProperties.getProfissu().getUrl() + LOGO_PATH,
         "code", code,
         "emailTitle", "Sign Up Confirmation",
         "emailMessage", "Thank you for signing up for Profisu! Please use the code below to confirm your registration:",
@@ -85,7 +83,7 @@ public class EmailService {
       String email,
       String code) {
     final var variables = Map.of(
-        "profissuLogoUrl", profissuUrl + LOGO_PATH,
+        "profissuLogoUrl", profissuProperties.getProfissu().getUrl() + LOGO_PATH,
         "code", code,
         "emailTitle", "Contact Confirmation",
         "emailMessage", "We received your contact request. Please use the code below to confirm your e-mail address:",
@@ -102,7 +100,7 @@ public class EmailService {
 
   public void sendRequestedServiceCancellationNotification(String title, String email) {
     final var variables = Map.of(
-        "profissuLogoUrl", profissuUrl + LOGO_PATH,
+        "profissuLogoUrl", profissuProperties.getProfissu().getUrl() + LOGO_PATH,
         "serviceName", title);
     final var sendEmailDto = new SendEmailDto(email, "Service Request Cancellation - Profisu",
         "service_request_cancellation_email.html", variables);

--- a/src/main/java/br/com/conectabyte/profissu/services/JwtService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/JwtService.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
@@ -16,24 +15,23 @@ import org.springframework.stereotype.Service;
 import br.com.conectabyte.profissu.dtos.response.LoginResponseDto;
 import br.com.conectabyte.profissu.entities.Role;
 import br.com.conectabyte.profissu.entities.User;
+import br.com.conectabyte.profissu.properties.ProfissuProperties;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class JwtService {
-  @Value("${spring.application.name}")
-  private String issuer;
-
   private final JwtEncoder jwtEncoder;
+  private final ProfissuProperties profissuProperties;
 
   public LoginResponseDto createJwtToken(User user) {
     final var now = Instant.now();
-    final var expiresIn = 300L;
+    final var expiresIn = profissuProperties.getProfissu().getJwt().getExpiresIn();
     final var scopes = user.getRoles().stream()
         .map(Role::getName)
         .collect(Collectors.joining(" "));
     final var claims = JwtClaimsSet.builder()
-        .issuer(issuer)
+        .issuer(profissuProperties.getSpring().getApplication().getName())
         .subject(user.getId().toString())
         .issuedAt(now)
         .expiresAt(now.plusSeconds(expiresIn))

--- a/src/main/java/br/com/conectabyte/profissu/services/UserService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/UserService.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -37,9 +36,6 @@ public class UserService {
   private final BCryptPasswordEncoder bCryptPasswordEncoder;
   private final EmailService emailService;
   private final TokenService tokenService;
-
-  @Value("${profissu.url}")
-  private String profissuUrl;
 
   private final UserMapper userMapper = UserMapper.INSTANCE;
 

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -10,4 +10,9 @@ server:
   port: 8081
 
 profissu:
+  jwt:
+    expires-in: 3600
   url: http://localhost:8081
+  allowed-origins:
+    - http://127.0.0.1:3000
+    - http://127.0.0.1:5500

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -29,3 +29,6 @@ server:
 
 profissu:
   url: http://localhost:8082
+  allowed-origins:
+    - http://127.0.0.1:3000
+    - http://127.0.0.1:5500

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -51,5 +51,9 @@ management:
 
 profissu:
   jwt:
+    expires-in: 300
     private-key-location: classpath:profissu.key
     public-key-location: classpath:profissu.pub
+  url: https://profissu-api.conectabyte.com.br
+  allowed-origins:
+    - https://conectabyte.com.br

--- a/src/test/java/br/com/conectabyte/profissu/config/interceptors/JwtAuthChannelInterceptorTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/config/interceptors/JwtAuthChannelInterceptorTest.java
@@ -1,0 +1,167 @@
+package br.com.conectabyte.profissu.config.interceptors;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+import br.com.conectabyte.profissu.repositories.ConversationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthChannelInterceptorTest {
+
+  @Mock
+  private JwtDecoder jwtDecoder;
+
+  @Mock
+  private ConversationRepository conversationRepository;
+
+  @InjectMocks
+  private JwtAuthChannelInterceptor interceptor;
+
+  @Test
+  void shouldAllowMessageWhenUserIsInConversation() {
+    final var token = "Bearer TOKEN";
+    final var claims = new HashMap<String, Object>();
+    final var now = Instant.now();
+
+    claims.put("sub", "1");
+
+    final var jwt = new Jwt(token, now, now.plusSeconds(1), claims, claims);
+
+    when(jwtDecoder.decode("TOKEN")).thenReturn(jwt);
+    when(conversationRepository.isUserInConversation(1L, 1L)).thenReturn(true);
+
+    final var accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+
+    accessor.setDestination("/topic/conversations/1/messages");
+    accessor.setNativeHeader("token", token);
+
+    final var message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    final var result = interceptor.preSend(message, null);
+
+    assertSame(message, result);
+  }
+
+  @Test
+  void shouldRejectMessageWhenUserNotInConversation() {
+    final var token = "Bearer TOKEN";
+    final var claims = new HashMap<String, Object>();
+    final var now = Instant.now();
+
+    claims.put("sub", 1);
+
+    final var jwt = new Jwt(token, now, now.plusSeconds(1), claims, claims);
+
+    when(jwtDecoder.decode("TOKEN")).thenReturn(jwt);
+    when(conversationRepository.isUserInConversation(1L, 1L)).thenReturn(false);
+
+    final var accessor = StompHeaderAccessor.create(StompCommand.SEND);
+
+    accessor.setDestination("/topic/conversations/1/messages");
+    accessor.setNativeHeader("token", token);
+
+    final var message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    final var result = interceptor.preSend(message, null);
+
+    assertNull(result);
+  }
+
+  @Test
+  void shouldRejectMessageWhenTokenIsInvalid() {
+    final var token = "Bearer TOKEN";
+
+    when(jwtDecoder.decode("TOKEN")).thenThrow(new RuntimeException("Invalid token"));
+
+    final var accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+
+    accessor.setDestination("/topic/conversations/1/messages");
+    accessor.setNativeHeader("token", token);
+
+    final var message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    final var result = interceptor.preSend(message, null);
+
+    assertNull(result);
+  }
+
+  @Test
+  void shouldRejectMessageWhenNoTokenProvided() {
+    final var accessor = StompHeaderAccessor.create(StompCommand.SEND);
+
+    accessor.setDestination("/topic/conversations/1/messages");
+
+    final var message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    final var result = interceptor.preSend(message, null);
+
+    assertNull(result);
+  }
+
+  @Test
+  void shouldRejectConnectIfTokenInvalid() {
+    final var accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+    accessor.setNativeHeader("token", " ");
+
+    final var message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    final var result = interceptor.preSend(message, null);
+
+    assertNull(result);
+  }
+
+  @Test
+  void shouldAllowConnectIfTokenValid() {
+    final var token = "Bearer TOKEN";
+    final var claims = new HashMap<String, Object>();
+    final var now = Instant.now();
+
+    claims.put("sub", "1");
+
+    final var jwt = new Jwt(token, now, now.plusSeconds(1), claims, claims);
+
+    when(jwtDecoder.decode(any())).thenReturn(jwt);
+
+    final var accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+    accessor.setNativeHeader("token", token);
+
+    final var message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    final var result = interceptor.preSend(message, null);
+
+    assertSame(message, result);
+  }
+
+  @Test
+  void shouldRejectMessageWhenDestinationIsInvalid() {
+    final var token = "Bearer TOKEN";
+    final var claims = new HashMap<String, Object>();
+    final var now = Instant.now();
+
+    claims.put("sub", "1");
+
+    final var jwt = new Jwt(token, now, now.plusSeconds(1), claims, claims);
+
+    when(jwtDecoder.decode("TOKEN")).thenReturn(jwt);
+
+    final var accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+
+    accessor.setDestination("/invalid/destination");
+    accessor.setNativeHeader("token", token);
+
+    final var message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    final var result = interceptor.preSend(message, null);
+
+    assertNull(result);
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/controllers/AddressControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/AddressControllerTest.java
@@ -24,13 +24,14 @@ import br.com.conectabyte.profissu.dtos.response.AddressResponseDto;
 import br.com.conectabyte.profissu.entities.Address;
 import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
 import br.com.conectabyte.profissu.mappers.AddressMapper;
+import br.com.conectabyte.profissu.properties.ProfissuProperties;
 import br.com.conectabyte.profissu.services.AddressService;
 import br.com.conectabyte.profissu.services.security.SecurityAddressService;
 import br.com.conectabyte.profissu.services.security.SecurityService;
 import br.com.conectabyte.profissu.utils.AddressUtils;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
-@WebMvcTest({ AddressController.class, SecurityService.class, SecurityAddressService.class })
+@WebMvcTest({ AddressController.class, SecurityService.class, SecurityAddressService.class, ProfissuProperties.class })
 @Import(SecurityConfig.class)
 class AddressControllerTest {
   @Autowired

--- a/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/AuthControllerTest.java
@@ -33,6 +33,7 @@ import br.com.conectabyte.profissu.entities.User;
 import br.com.conectabyte.profissu.exceptions.EmailNotVerifiedException;
 import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
 import br.com.conectabyte.profissu.mappers.UserMapper;
+import br.com.conectabyte.profissu.properties.ProfissuProperties;
 import br.com.conectabyte.profissu.services.ContactService;
 import br.com.conectabyte.profissu.services.LoginService;
 import br.com.conectabyte.profissu.services.UserService;
@@ -40,7 +41,7 @@ import br.com.conectabyte.profissu.utils.AddressUtils;
 import br.com.conectabyte.profissu.utils.ContactUtils;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
-@WebMvcTest(AuthController.class)
+@WebMvcTest({ AuthController.class, ProfissuProperties.class })
 @Import(SecurityConfig.class)
 public class AuthControllerTest {
   private final UserMapper userMapper = UserMapper.INSTANCE;

--- a/src/test/java/br/com/conectabyte/profissu/controllers/ContactControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/ContactControllerTest.java
@@ -24,6 +24,7 @@ import br.com.conectabyte.profissu.dtos.response.ContactResponseDto;
 import br.com.conectabyte.profissu.entities.Contact;
 import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
 import br.com.conectabyte.profissu.mappers.ContactMapper;
+import br.com.conectabyte.profissu.properties.ProfissuProperties;
 import br.com.conectabyte.profissu.services.ContactService;
 import br.com.conectabyte.profissu.services.UserService;
 import br.com.conectabyte.profissu.services.security.SecurityContactService;
@@ -31,7 +32,7 @@ import br.com.conectabyte.profissu.services.security.SecurityService;
 import br.com.conectabyte.profissu.utils.ContactUtils;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
-@WebMvcTest({ ContactController.class, SecurityService.class, SecurityContactService.class })
+@WebMvcTest({ ContactController.class, SecurityService.class, SecurityContactService.class, ProfissuProperties.class })
 @Import(SecurityConfig.class)
 class ContactControllerTest {
   @Autowired

--- a/src/test/java/br/com/conectabyte/profissu/controllers/RequestedServiceControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/RequestedServiceControllerTest.java
@@ -30,13 +30,15 @@ import br.com.conectabyte.profissu.enums.RequestedServiceStatusEnum;
 import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
 import br.com.conectabyte.profissu.mappers.AddressMapper;
 import br.com.conectabyte.profissu.mappers.UserMapper;
+import br.com.conectabyte.profissu.properties.ProfissuProperties;
 import br.com.conectabyte.profissu.services.RequestedServiceService;
 import br.com.conectabyte.profissu.services.security.SecurityRequestedServiceService;
 import br.com.conectabyte.profissu.services.security.SecurityService;
 import br.com.conectabyte.profissu.utils.AddressUtils;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
-@WebMvcTest({ RequestedServiceController.class, SecurityService.class, SecurityRequestedServiceService.class })
+@WebMvcTest({ RequestedServiceController.class, SecurityService.class, SecurityRequestedServiceService.class,
+    ProfissuProperties.class })
 @Import(SecurityConfig.class)
 class RequestedServiceControllerTest {
   @MockitoBean

--- a/src/test/java/br/com/conectabyte/profissu/controllers/UserControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/UserControllerTest.java
@@ -36,6 +36,7 @@ import br.com.conectabyte.profissu.mappers.ContactMapper;
 import br.com.conectabyte.profissu.mappers.ConversationMapper;
 import br.com.conectabyte.profissu.mappers.RequestedServiceMapper;
 import br.com.conectabyte.profissu.mappers.UserMapper;
+import br.com.conectabyte.profissu.properties.ProfissuProperties;
 import br.com.conectabyte.profissu.services.ConversationService;
 import br.com.conectabyte.profissu.services.RequestedServiceService;
 import br.com.conectabyte.profissu.services.UserService;
@@ -46,7 +47,7 @@ import br.com.conectabyte.profissu.utils.ConversationUtils;
 import br.com.conectabyte.profissu.utils.RequestedServiceUtils;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
-@WebMvcTest({ UserController.class, SecurityService.class })
+@WebMvcTest({ UserController.class, SecurityService.class, ProfissuProperties.class })
 @Import(SecurityConfig.class)
 public class UserControllerTest {
   private final UserMapper userMapper = UserMapper.INSTANCE;

--- a/src/test/java/br/com/conectabyte/profissu/services/EmailServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/EmailServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,6 +17,8 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
+import br.com.conectabyte.profissu.properties.ProfissuProperties;
+import br.com.conectabyte.profissu.utils.PropertiesLoader;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 
@@ -27,8 +30,18 @@ class EmailServiceTest {
   @Mock
   private TemplateEngine templateEngine;
 
+  @Mock
+  private ProfissuProperties profissuProperties;
+
   @InjectMocks
   private EmailService emailService;
+
+  @BeforeEach
+  void before() throws Exception {
+    final var loadedProfissuProperties = new PropertiesLoader().loadProperties();
+
+    when(profissuProperties.getProfissu()).thenReturn(loadedProfissuProperties.getProfissu());
+  }
 
   @Test
   void shouldSendPasswordRecoveryEmailSuccessfully() throws MessagingException {

--- a/src/test/java/br/com/conectabyte/profissu/services/JwtServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/JwtServiceTest.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -25,6 +24,8 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 
+import br.com.conectabyte.profissu.properties.ProfissuProperties;
+import br.com.conectabyte.profissu.utils.PropertiesLoader;
 import br.com.conectabyte.profissu.utils.RoleUtils;
 import br.com.conectabyte.profissu.utils.UserUtils;
 
@@ -33,14 +34,17 @@ public class JwtServiceTest {
   @Mock
   private JwtEncoder jwtEncoder;
 
+  @Mock
+  private ProfissuProperties profissuProperties;
+
   @InjectMocks
   private JwtService jwtService;
 
-  @BeforeEach
   void setUp() throws Exception {
-    var issuerField = JwtService.class.getDeclaredField("issuer");
-    issuerField.setAccessible(true);
-    issuerField.set(jwtService, "profissu");
+    final var loadedProfissuProperties = new PropertiesLoader().loadProperties();
+
+    when(profissuProperties.getProfissu()).thenReturn(loadedProfissuProperties.getProfissu());
+    when(profissuProperties.getSpring()).thenReturn(loadedProfissuProperties.getSpring());
   }
 
   @AfterEach
@@ -49,7 +53,8 @@ public class JwtServiceTest {
   }
 
   @Test
-  void shouldReturnTokenWhenSuccess() {
+  void shouldReturnTokenWhenSuccess() throws Exception {
+    setUp();
     final var user = UserUtils.create();
     final var now = Instant.now();
     final var map = Map.of("key", new Object());
@@ -68,7 +73,8 @@ public class JwtServiceTest {
   }
 
   @Test
-  void shouldContainCorrectClaims() {
+  void shouldContainCorrectClaims() throws Exception {
+    setUp();
     final var user = UserUtils.create();
     final var now = Instant.now();
     final var map = Map.of("key", new Object());

--- a/src/test/java/br/com/conectabyte/profissu/utils/AddressUtils.java
+++ b/src/test/java/br/com/conectabyte/profissu/utils/AddressUtils.java
@@ -5,7 +5,7 @@ import br.com.conectabyte.profissu.entities.User;
 
 public class AddressUtils {
   public static Address create(User user) {
-    var address = new Address();
+    final var address = new Address();
 
     address.setStreet("123 Main St");
     address.setNumber("101");

--- a/src/test/java/br/com/conectabyte/profissu/utils/ConversationUtils.java
+++ b/src/test/java/br/com/conectabyte/profissu/utils/ConversationUtils.java
@@ -11,7 +11,7 @@ import br.com.conectabyte.profissu.enums.OfferStatusEnum;
 public class ConversationUtils {
   public static Conversation create(User requester, User serviceProvider, RequestedService requestedService,
       List<Message> messages) {
-    var conversation = new Conversation();
+    final var conversation = new Conversation();
 
     conversation.setOfferStatus(OfferStatusEnum.PENDING);
     conversation.setRequester(requester);

--- a/src/test/java/br/com/conectabyte/profissu/utils/MessageUtils.java
+++ b/src/test/java/br/com/conectabyte/profissu/utils/MessageUtils.java
@@ -1,0 +1,18 @@
+package br.com.conectabyte.profissu.utils;
+
+import br.com.conectabyte.profissu.entities.Conversation;
+import br.com.conectabyte.profissu.entities.Message;
+import br.com.conectabyte.profissu.entities.User;
+
+public class MessageUtils {
+  public static Message create(User user, Conversation conversation) {
+    final var message = new Message();
+
+    message.setMessage("Teste");
+    message.setRead(false);
+    message.setUser(user);
+    message.setConversation(conversation);
+
+    return message;
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/utils/PropertiesLoader.java
+++ b/src/test/java/br/com/conectabyte/profissu/utils/PropertiesLoader.java
@@ -1,0 +1,31 @@
+package br.com.conectabyte.profissu.utils;
+
+import java.io.InputStream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import br.com.conectabyte.profissu.properties.ProfissuProperties;
+
+public class PropertiesLoader {
+  public ProfissuProperties loadProperties() throws Exception {
+    final var objectMapper = new ObjectMapper(new YAMLFactory());
+    var profissuProperties = new ProfissuProperties();
+    var profissuPropertiesTest = new ProfissuProperties();
+
+    objectMapper.findAndRegisterModules();
+
+    try (InputStream input = getClass().getClassLoader().getResourceAsStream("application.yaml")) {
+      profissuProperties = objectMapper.readValue(input, ProfissuProperties.class);
+    }
+
+    try (InputStream input = getClass().getClassLoader().getResourceAsStream("application-test.yaml")) {
+      profissuPropertiesTest = objectMapper.readValue(input, ProfissuProperties.class);
+    }
+
+    profissuPropertiesTest.setSpring(profissuProperties.getSpring());
+    profissuPropertiesTest.getProfissu().setJwt(profissuProperties.getProfissu().getJwt());
+
+    return profissuPropertiesTest;
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/utils/RoleUtils.java
+++ b/src/test/java/br/com/conectabyte/profissu/utils/RoleUtils.java
@@ -8,7 +8,7 @@ public class RoleUtils {
   }
 
   public static Role create(String name) {
-    var role = new Role();
+    final var role = new Role();
 
     role.setName(name);
 

--- a/src/test/java/br/com/conectabyte/profissu/utils/UserUtils.java
+++ b/src/test/java/br/com/conectabyte/profissu/utils/UserUtils.java
@@ -5,7 +5,7 @@ import br.com.conectabyte.profissu.enums.GenderEnum;
 
 public class UserUtils {
   public static User create() {
-    var user = new User();
+    final var user = new User();
 
     user.setName("Test Test");
     user.setBio("Bio");


### PR DESCRIPTION
### Description
This PR implements message sending security for conversations via WebSocket, ensuring that only authenticated users who are participants of a conversation can send or subscribe to messages related to that conversation.

### Main Changes
- **Added conversation authorization:** Validated that users can only send or subscribe to messages if they are participants of the conversation.
- **Implemented token validation:** Decoded and verified the JWT token for each WebSocket message to authenticate the user.
- **Enhanced destination validation:** Ensured that only destinations matching the expected conversation pattern are accepted, rejecting invalid destinations to improve security.
- **Added unit tests:** Covered scenarios including valid and invalid tokens, user not being part of the conversation, and invalid conversation destinations.
- **Documented behavior:** Clarified the security mechanism and validation flow in the code, improving maintainability and understanding for future developers.