### PR TITLE
Create endpoint to mark messages as read

### DIFF
--- a/src/main/java/br/com/conectabyte/profissu/controllers/MessageController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/MessageController.java
@@ -1,0 +1,25 @@
+package br.com.conectabyte.profissu.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.conectabyte.profissu.services.MessageService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/messages")
+@RequiredArgsConstructor
+public class MessageController {
+  private final MessageService messageService;
+
+  @PreAuthorize("@securityConversationService.ownershipCheck(#id) || @securityConversationService.requestedServiceOwner(#id) || @securityService.isAdmin()")
+  @PatchMapping("/{id}/read")
+  public ResponseEntity<Void> markMessageAsRead(@PathVariable Long id) {
+    messageService.markAsRead(id);
+    return ResponseEntity.accepted().build();
+  }
+}

--- a/src/main/java/br/com/conectabyte/profissu/controllers/MessageController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/MessageController.java
@@ -32,7 +32,7 @@ public class MessageController {
       @ApiResponse(responseCode = "403", description = "Forbidden - access denied", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
       @ApiResponse(responseCode = "404", description = "Message not found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
   })
-  @PreAuthorize("@securityConversationService.ownershipCheck(#id) || @securityConversationService.requestedServiceOwner(#id) || @securityService.isAdmin()")
+  @PreAuthorize("((@securityMessageService.ownershipCheck(#id) || @securityMessageService.requestedServiceOwner(#id)) && @securityMessageService.messageReciver(#id)) || @securityService.isAdmin()")
   @PatchMapping("/{id}/read")
   public ResponseEntity<Void> markMessageAsRead(@PathVariable Long id) {
     messageService.markAsRead(id);

--- a/src/main/java/br/com/conectabyte/profissu/controllers/MessageController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/MessageController.java
@@ -7,15 +7,31 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import br.com.conectabyte.profissu.dtos.response.ExceptionDto;
 import br.com.conectabyte.profissu.services.MessageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/messages")
 @RequiredArgsConstructor
+@Tag(name = "Messages", description = "Operations related to managing messages")
 public class MessageController {
   private final MessageService messageService;
 
+  @Operation(summary = "Mark a message as read", description = "Allows a participant of the conversation or an admin to mark a specific message as read to prevent repeated notifications.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "Message successfully marked as read"),
+      @ApiResponse(responseCode = "400", description = "Invalid request parameters", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "401", description = "Unauthorized - missing or invalid authentication credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "403", description = "Forbidden - access denied", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "404", description = "Message not found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
+  })
   @PreAuthorize("@securityConversationService.ownershipCheck(#id) || @securityConversationService.requestedServiceOwner(#id) || @securityService.isAdmin()")
   @PatchMapping("/{id}/read")
   public ResponseEntity<Void> markMessageAsRead(@PathVariable Long id) {

--- a/src/main/java/br/com/conectabyte/profissu/services/MessageService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/MessageService.java
@@ -1,0 +1,23 @@
+package br.com.conectabyte.profissu.services;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
+import br.com.conectabyte.profissu.repositories.MessageRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+  private final MessageRepository messageRepository;
+
+  @Async
+  public void markAsRead(Long id) {
+    final var message = messageRepository.findById(id)
+        .orElseThrow(() -> new ResourceNotFoundException("Message not found"));
+
+    message.setRead(true);
+    messageRepository.save(message);
+  }
+}

--- a/src/main/java/br/com/conectabyte/profissu/services/MessageService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/MessageService.java
@@ -3,6 +3,7 @@ package br.com.conectabyte.profissu.services;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import br.com.conectabyte.profissu.entities.Message;
 import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
 import br.com.conectabyte.profissu.repositories.MessageRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,10 +13,16 @@ import lombok.RequiredArgsConstructor;
 public class MessageService {
   private final MessageRepository messageRepository;
 
+  public Message findById(Long id) {
+    final var optionalMessage = messageRepository.findById(id);
+    final var message = optionalMessage.orElseThrow(() -> new ResourceNotFoundException("Message not found."));
+
+    return message;
+  }
+
   @Async
   public void markAsRead(Long id) {
-    final var message = messageRepository.findById(id)
-        .orElseThrow(() -> new ResourceNotFoundException("Message not found"));
+    final var message = this.findById(id);
 
     message.setRead(true);
     messageRepository.save(message);

--- a/src/main/java/br/com/conectabyte/profissu/services/security/SecurityAddressService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/security/SecurityAddressService.java
@@ -15,6 +15,7 @@ public class SecurityAddressService implements OwnerCheck {
   public boolean ownershipCheck(Long id) {
     try {
       final var address = addressService.findById(id);
+
       return securityService.isOwner(address.getUser().getId());
     } catch (Exception e) {
       return false;

--- a/src/main/java/br/com/conectabyte/profissu/services/security/SecurityContactService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/security/SecurityContactService.java
@@ -15,6 +15,7 @@ public class SecurityContactService implements OwnerCheck {
   public boolean ownershipCheck(Long id) {
     try {
       final var contact = contactService.findById(id);
+
       return securityService.isOwner(contact.getUser().getId());
     } catch (Exception e) {
       return false;

--- a/src/main/java/br/com/conectabyte/profissu/services/security/SecurityConversationService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/security/SecurityConversationService.java
@@ -15,6 +15,7 @@ public class SecurityConversationService implements OwnerCheck {
   public boolean ownershipCheck(Long id) {
     try {
       final var conversation = conversationService.findById(id);
+
       return securityService.isOwner(conversation.getServiceProvider().getId());
     } catch (Exception e) {
       return false;
@@ -24,6 +25,7 @@ public class SecurityConversationService implements OwnerCheck {
   public boolean requestedServiceOwner(Long id) {
     try {
       final var conversation = conversationService.findById(id);
+
       return securityService.isOwner(conversation.getRequester().getId());
     } catch (Exception e) {
       return false;

--- a/src/main/java/br/com/conectabyte/profissu/services/security/SecurityMessageService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/security/SecurityMessageService.java
@@ -1,0 +1,44 @@
+package br.com.conectabyte.profissu.services.security;
+
+import org.springframework.stereotype.Service;
+
+import br.com.conectabyte.profissu.services.MessageService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SecurityMessageService implements OwnerCheck {
+  private final MessageService messageService;
+  private final SecurityService securityService;
+
+  @Override
+  public boolean ownershipCheck(Long id) {
+    try {
+      final var message = messageService.findById(id);
+
+      return securityService.isOwner(message.getConversation().getServiceProvider().getId());
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  public boolean requestedServiceOwner(Long id) {
+    try {
+      final var message = messageService.findById(id);
+
+      return securityService.isOwner(message.getConversation().getRequester().getId());
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  public boolean messageReciver(Long id) {
+    try {
+      final var message = messageService.findById(id);
+
+      return !securityService.isOwner(message.getUser().getId());
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/br/com/conectabyte/profissu/services/security/SecurityRequestedServiceService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/security/SecurityRequestedServiceService.java
@@ -15,6 +15,7 @@ public class SecurityRequestedServiceService implements OwnerCheck {
   public boolean ownershipCheck(Long id) {
     try {
       final var requestedService = requestedServiceService.findById(id);
+
       return securityService.isOwner(requestedService.getUser().getId());
     } catch (Exception e) {
       return false;

--- a/src/test/java/br/com/conectabyte/profissu/controllers/MessageControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/MessageControllerTest.java
@@ -1,0 +1,91 @@
+package br.com.conectabyte.profissu.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import br.com.conectabyte.profissu.properties.ProfissuProperties;
+import br.com.conectabyte.profissu.services.MessageService;
+import br.com.conectabyte.profissu.services.security.SecurityMessageService;
+import br.com.conectabyte.profissu.services.security.SecurityService;
+
+@WebMvcTest({ MessageController.class, SecurityService.class, SecurityMessageService.class, ProfissuProperties.class })
+@Import(br.com.conectabyte.profissu.config.SecurityConfig.class)
+class MessageControllerTest {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private MessageService messageService;
+
+  @MockitoBean
+  private SecurityService securityService;
+
+  @MockitoBean
+  private SecurityMessageService securityMessageService;
+
+  @Test
+  @WithMockUser
+  void shouldMarkMessageAsReadWhenUserIsAdmin() throws Exception {
+    when(securityService.isAdmin()).thenReturn(true);
+    doNothing().when(messageService).markAsRead(any());
+
+    mockMvc.perform(patch("/messages/1/read"))
+        .andExpect(status().isAccepted());
+  }
+
+  @Test
+  @WithMockUser
+  void shouldMarkMessageAsReadWhenUserIsServiceProvider() throws Exception {
+    when(securityMessageService.ownershipCheck(any())).thenReturn(true);
+    when(securityMessageService.messageReciver(any())).thenReturn(true);
+    doNothing().when(messageService).markAsRead(any());
+
+    mockMvc.perform(patch("/messages/1/read"))
+        .andExpect(status().isAccepted());
+  }
+
+  @Test
+  @WithMockUser
+  void shouldMarkMessageAsReadWhenUserIsServiceRequester() throws Exception {
+    when(securityMessageService.requestedServiceOwner(any())).thenReturn(true);
+    when(securityMessageService.messageReciver(any())).thenReturn(true);
+    doNothing().when(messageService).markAsRead(any());
+
+    mockMvc.perform(patch("/messages/1/read"))
+        .andExpect(status().isAccepted());
+  }
+
+  @Test
+  @WithMockUser
+  void shouldReturnForbiddenWhenUserIsMessageOwner() throws Exception {
+    when(securityMessageService.requestedServiceOwner(any())).thenReturn(true);
+    when(securityMessageService.messageReciver(any())).thenReturn(false);
+    doNothing().when(messageService).markAsRead(any());
+
+    mockMvc.perform(patch("/messages/1/read"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("Access denied."));
+  }
+
+  @Test
+  @WithMockUser
+  void shouldReturnForbiddenWhenUserHasNoPermission() throws Exception {
+    doNothing().when(messageService).markAsRead(any());
+
+    mockMvc.perform(patch("/messages/1/read"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("Access denied."));
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/services/MessageServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/MessageServiceTest.java
@@ -1,0 +1,64 @@
+package br.com.conectabyte.profissu.services;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import br.com.conectabyte.profissu.entities.Message;
+import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
+import br.com.conectabyte.profissu.repositories.MessageRepository;
+import br.com.conectabyte.profissu.utils.MessageUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MessageServiceTest {
+
+  @Mock
+  private MessageRepository messageRepository;
+
+  @InjectMocks
+  private MessageService messageService;
+
+  @Test
+  void shouldFindMessageByIdWhenExists() {
+    final var message = MessageUtils.create(null, null);
+    when(messageRepository.findById(any())).thenReturn(Optional.of(message));
+
+    Message foundMessage = messageService.findById(1L);
+
+    assert (foundMessage).equals(message);
+    verify(messageRepository).findById(any());
+  }
+
+  @Test
+  void shouldThrowResourceNotFoundWhenMessageDoesNotExist() {
+    when(messageRepository.findById(any())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> messageService.findById(1L))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessage("Message not found.");
+
+    verify(messageRepository).findById(any());
+  }
+
+  @Test
+  void shouldMarkMessageAsReadWhenExists() {
+    final var message = MessageUtils.create(null, null);
+    when(messageRepository.findById(any())).thenReturn(Optional.of(message));
+    when(messageRepository.save(any(Message.class))).thenReturn(message);
+
+    messageService.markAsRead(1L);
+
+    assert (message.isRead());
+    verify(messageRepository).findById(any());
+    verify(messageRepository).save(message);
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/services/security/SecurityMessageServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/security/SecurityMessageServiceTest.java
@@ -1,0 +1,157 @@
+package br.com.conectabyte.profissu.services.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
+import br.com.conectabyte.profissu.services.MessageService;
+import br.com.conectabyte.profissu.utils.ConversationUtils;
+import br.com.conectabyte.profissu.utils.MessageUtils;
+import br.com.conectabyte.profissu.utils.UserUtils;
+
+@ExtendWith(MockitoExtension.class)
+class SecurityMessageServiceTest {
+
+  @Mock
+  private MessageService messageService;
+
+  @Mock
+  private SecurityService securityService;
+
+  @InjectMocks
+  private SecurityMessageService securityMessageService;
+
+  @Test
+  void shouldReturnTrueWhenUserIsOwnerOfServiceProvider() {
+    final var user = UserUtils.create();
+
+    user.setId(1L);
+
+    final var conversation = ConversationUtils.create(null, user, null, null);
+    final var message = MessageUtils.create(null, conversation);
+
+    when(messageService.findById(any())).thenReturn(message);
+    when(securityService.isOwner(any())).thenReturn(true);
+
+    final var isOwner = securityMessageService.ownershipCheck(1L);
+
+    assertTrue(isOwner);
+  }
+
+  @Test
+  void shouldReturnFalseWhenUserIsNotOwnerOfServiceProvider() {
+    final var user = UserUtils.create();
+
+    user.setId(1L);
+
+    final var conversation = ConversationUtils.create(user, null, null, null);
+    final var message = MessageUtils.create(null, conversation);
+
+    when(messageService.findById(any())).thenReturn(message);
+
+    final var isOwner = securityMessageService.ownershipCheck(1L);
+
+    assertFalse(isOwner);
+  }
+
+  @Test
+  void shouldReturnFalseWhenMessageNotFoundInOwnershipCheck() {
+    when(messageService.findById(any())).thenThrow(new ResourceNotFoundException("Message not found"));
+
+    final var isOwner = securityMessageService.ownershipCheck(1L);
+
+    assertFalse(isOwner);
+  }
+
+  @Test
+  void shouldReturnTrueWhenUserIsOwnerOfRequestedService() {
+    final var user = UserUtils.create();
+
+    user.setId(1L);
+
+    final var conversation = ConversationUtils.create(user, null, null, null);
+    final var message = MessageUtils.create(null, conversation);
+
+    when(messageService.findById(any())).thenReturn(message);
+    when(securityService.isOwner(any())).thenReturn(true);
+
+    final var isOwner = securityMessageService.requestedServiceOwner(1L);
+
+    assertTrue(isOwner);
+  }
+
+  @Test
+  void shouldReturnFalseWhenUserIsNotOwnerOfRequestedService() {
+    final var user = UserUtils.create();
+
+    user.setId(1L);
+
+    final var conversation = ConversationUtils.create(user, null, null, null);
+    final var message = MessageUtils.create(null, conversation);
+
+    when(messageService.findById(any())).thenReturn(message);
+    when(securityService.isOwner(any())).thenReturn(false);
+
+    final var isOwner = securityMessageService.requestedServiceOwner(1L);
+
+    assertFalse(isOwner);
+  }
+
+  @Test
+  void shouldReturnFalseWhenMessageNotFoundInRequestedServiceOwner() {
+    when(messageService.findById(any())).thenThrow(new ResourceNotFoundException("Message not found"));
+
+    final var isOwner = securityMessageService.requestedServiceOwner(1L);
+
+    assertFalse(isOwner);
+  }
+
+  @Test
+  void shouldReturnTrueWhenUserIsNotTheMessageReceiver() {
+    final var user = UserUtils.create();
+
+    user.setId(1L);
+
+    final var message = MessageUtils.create(user, null);
+
+    when(messageService.findById(any())).thenReturn(message);
+    when(securityService.isOwner(any())).thenReturn(false);
+
+    final var isReceiver = securityMessageService.messageReciver(1L);
+
+    assertTrue(isReceiver);
+  }
+
+  @Test
+  void shouldReturnFalseWhenUserIsTheMessageReceiver() {
+    final var user = UserUtils.create();
+
+    user.setId(1L);
+
+    final var message = MessageUtils.create(user, null);
+
+    when(messageService.findById(any())).thenReturn(message);
+    when(securityService.isOwner(any())).thenReturn(true);
+
+    final var isReceiver = securityMessageService.messageReciver(1L);
+
+    assertFalse(isReceiver);
+  }
+
+  @Test
+  void shouldReturnFalseWhenMessageNotFoundInMessageReceiver() {
+    when(messageService.findById(any())).thenThrow(new ResourceNotFoundException("Message not found"));
+
+    final var isReceiver = securityMessageService.messageReciver(1L);
+
+    assertFalse(isReceiver);
+  }
+}


### PR DESCRIPTION
### Description
This pull request adds the functionality to mark messages as read, preventing repeated notifications for conversation participants.

### Main Changes
- **Endpoint:** created PATCH `/messages/{id}/read` to update the read status of a message.
- **Documentation:** added OpenAPI (Swagger) annotations to detail the endpoint and its responses.
- **Tests:** included tests to ensure the correct functioning of the endpoint.