### PR TITLE
Create endpoint to delete feedback

### DIFF
--- a/src/main/java/br/com/conectabyte/profissu/controllers/ReviewController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/ReviewController.java
@@ -56,6 +56,12 @@ public class ReviewController {
     return ResponseEntity.ok().body(this.reviewService.register(requestedServiceId, reviewRequestDto));
   }
 
+  @Operation(summary = "Delete review", description = "Allows the user to delete a review they have submitted.", responses = {
+      @ApiResponse(responseCode = "202", description = "Review successfully deleted"),
+      @ApiResponse(responseCode = "403", description = "User is not authorized to delete this review", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "400", description = "Malformed ID", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "404", description = "Review not found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
+  })
   @PreAuthorize("@securityReviewService.ownershipCheck(#id) || @securityService.isAdmin()")
   @DeleteMapping("{id}")
   public ResponseEntity<Void> deleteById(@PathVariable Long id) {

--- a/src/main/java/br/com/conectabyte/profissu/controllers/ReviewController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/ReviewController.java
@@ -5,7 +5,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -52,5 +54,12 @@ public class ReviewController {
   public ResponseEntity<ReviewResponseDto> register(@RequestParam Long requestedServiceId,
       @Valid @RequestBody ReviewRequestDto reviewRequestDto) {
     return ResponseEntity.ok().body(this.reviewService.register(requestedServiceId, reviewRequestDto));
+  }
+
+  @PreAuthorize("@securityReviewService.ownershipCheck(#id) || @securityService.isAdmin()")
+  @DeleteMapping("{id}")
+  public ResponseEntity<Void> deleteById(@PathVariable Long id) {
+    this.reviewService.deleteById(id);
+    return ResponseEntity.accepted().build();
   }
 }

--- a/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
+++ b/src/main/java/br/com/conectabyte/profissu/controllers/UserController.java
@@ -44,7 +44,7 @@ public class UserController {
 
   @Operation(summary = "Soft delete user profile", description = "Marks the user profile as deleted (soft delete) using the provided ID. Requires authentication.", responses = {
       @ApiResponse(responseCode = "202", description = "The user profile will be soft deleted"),
-      @ApiResponse(responseCode = "400", description = "Malformed ID or missing parameters", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
+      @ApiResponse(responseCode = "400", description = "Malformed ID", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
       @ApiResponse(responseCode = "401", description = "Invalid or missing authentication credentials", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class))),
       @ApiResponse(responseCode = "403", description = "User does not have permission to delete this profile", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionDto.class)))
   })

--- a/src/main/java/br/com/conectabyte/profissu/mappers/RequestedServiceMapper.java
+++ b/src/main/java/br/com/conectabyte/profissu/mappers/RequestedServiceMapper.java
@@ -21,6 +21,7 @@ public interface RequestedServiceMapper {
   @Mapping(target = "user", ignore = true)
   @Mapping(target = "status", ignore = true)
   @Mapping(target = "conversations", ignore = true)
+  @Mapping(target = "reviews", ignore = true)
   RequestedService requestedServiceRequestDtoToRequestedService(RequestedServiceRequestDto requestedServiceRequestDto);
 
   RequestedServiceResponseDto requestedServiceToRequestedServiceResponseDto(

--- a/src/main/java/br/com/conectabyte/profissu/mappers/UserMapper.java
+++ b/src/main/java/br/com/conectabyte/profissu/mappers/UserMapper.java
@@ -23,6 +23,7 @@ public interface UserMapper {
   @Mapping(target = "updatedAt", ignore = true)
   @Mapping(target = "token", ignore = true)
   @Mapping(target = "requestedService", ignore = true)
+  @Mapping(target = "reviews", ignore = true)
   User userRequestDtoToUser(UserRequestDto userRequestDto);
 
   UserRequestDto userToUserRequestDto(User user);

--- a/src/main/java/br/com/conectabyte/profissu/repositories/ReviewRepository.java
+++ b/src/main/java/br/com/conectabyte/profissu/repositories/ReviewRepository.java
@@ -18,13 +18,15 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   @Query("""
       FROM Review r
         WHERE r.user.id <> :userId
-        AND r.requestedService.id IN (
-            SELECT DISTINCT rs.id
-              FROM RequestedService rs
-              JOIN rs.conversations c
-                WHERE c.requester.id = :userId
-                OR c.serviceProvider.id = :userId
-          )
+        AND r.requestedService.id
+        IN (
+          SELECT DISTINCT rs.id
+            FROM RequestedService rs
+            JOIN rs.conversations c
+              WHERE c.requester.id = :userId
+              OR c.serviceProvider.id = :userId
+        )
+        AND r.deletedAt IS NULL
       """)
   Page<Review> findReviewsReceivedByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/br/com/conectabyte/profissu/services/ReviewService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/ReviewService.java
@@ -1,12 +1,17 @@
 package br.com.conectabyte.profissu.services;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import br.com.conectabyte.profissu.dtos.request.ReviewRequestDto;
 import br.com.conectabyte.profissu.dtos.response.ReviewResponseDto;
+import br.com.conectabyte.profissu.entities.Review;
 import br.com.conectabyte.profissu.enums.RequestedServiceStatusEnum;
+import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
 import br.com.conectabyte.profissu.exceptions.ValidationException;
 import br.com.conectabyte.profissu.mappers.ReviewMapper;
 import br.com.conectabyte.profissu.repositories.ReviewRepository;
@@ -22,6 +27,13 @@ public class ReviewService {
   private final JwtService jwtService;
 
   private final ReviewMapper reviewMapper = ReviewMapper.INSTANCE;
+
+  public Review findById(Long id) {
+    final var optionalReview = this.reviewRepository.findById(id);
+    final var review = optionalReview.orElseThrow(() -> new ResourceNotFoundException("User not found."));
+
+    return review;
+  }
 
   @Transactional
   public ReviewResponseDto register(Long requestedServiceId, ReviewRequestDto reviewRequestDto) {
@@ -48,5 +60,16 @@ public class ReviewService {
         : reviewRepository.findReviewsReceivedByUserId(userId, pageable);
 
     return reviewMapper.reviewPageToReviewResponseDtoPage(reviews);
+  }
+
+  @Async
+  @Transactional
+  public void deleteById(Long id) {
+    final var optionalReview = this.reviewRepository.findById(id);
+
+    optionalReview.ifPresent(review -> {
+      review.setDeletedAt(LocalDateTime.now());
+      reviewRepository.save(review);
+    });
   }
 }

--- a/src/main/java/br/com/conectabyte/profissu/services/security/SecurityReviewService.java
+++ b/src/main/java/br/com/conectabyte/profissu/services/security/SecurityReviewService.java
@@ -1,0 +1,24 @@
+package br.com.conectabyte.profissu.services.security;
+
+import org.springframework.stereotype.Service;
+
+import br.com.conectabyte.profissu.services.ReviewService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SecurityReviewService implements OwnerCheck {
+  private final ReviewService reviewService;
+  private final SecurityService securityService;
+
+  @Override
+  public boolean ownershipCheck(Long id) {
+    try {
+      final var address = reviewService.findById(id);
+
+      return securityService.isOwner(address.getUser().getId());
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/controllers/MessageControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/MessageControllerTest.java
@@ -52,8 +52,8 @@ class MessageControllerTest {
   @Test
   @WithMockUser
   void shouldSendMessageSuccessfullyWhenIsConversationOwner() throws Exception {
-    final var messageResponseDto = new MessageResponseDto(null, "Teste", false, null);
-    final var messageRequestDto = new MessageRequestDto("Teste");
+    final var messageResponseDto = new MessageResponseDto(null, "Test", false, null);
+    final var messageRequestDto = new MessageRequestDto("Test");
 
     when(securityConversationService.ownershipCheck(any())).thenReturn(true);
     when(messageService.sendMessage(any(), any())).thenReturn(messageResponseDto);
@@ -63,14 +63,14 @@ class MessageControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(messageRequestDto)))
         .andExpect(status().isCreated())
-        .andExpect(jsonPath("$.message").value("Teste"));
+        .andExpect(jsonPath("$.message").value("Test"));
   }
 
   @Test
   @WithMockUser
   void shouldSendMessageSuccessfullyWhenIsRequestedServiceOwner() throws Exception {
-    final var messageResponseDto = new MessageResponseDto(null, "Teste", false, null);
-    final var messageRequestDto = new MessageRequestDto("Teste");
+    final var messageResponseDto = new MessageResponseDto(null, "Test", false, null);
+    final var messageRequestDto = new MessageRequestDto("Test");
 
     when(securityConversationService.isRequestedServiceOwner(any())).thenReturn(true);
     when(messageService.sendMessage(any(), any())).thenReturn(messageResponseDto);
@@ -80,14 +80,14 @@ class MessageControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(messageRequestDto)))
         .andExpect(status().isCreated())
-        .andExpect(jsonPath("$.message").value("Teste"));
+        .andExpect(jsonPath("$.message").value("Test"));
   }
 
   @Test
   @WithMockUser
   void shouldListMessagesSuccessfully() throws Exception {
-    final var message1 = new MessageResponseDto(1L, "Teste 1", false, null);
-    final var message2 = new MessageResponseDto(2L, "Teste 2", false, null);
+    final var message1 = new MessageResponseDto(1L, "Test 1", false, null);
+    final var message2 = new MessageResponseDto(2L, "Test 2", false, null);
     final var messages = new PageImpl<>(List.of(message1, message2));
 
     when(securityConversationService.ownershipCheck(any())).thenReturn(true);
@@ -101,8 +101,8 @@ class MessageControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.content").isArray())
         .andExpect(jsonPath("$.content.length()").value(2))
-        .andExpect(jsonPath("$.content[0].message").value("Teste 1"))
-        .andExpect(jsonPath("$.content[1].message").value("Teste 2"));
+        .andExpect(jsonPath("$.content[0].message").value("Test 1"))
+        .andExpect(jsonPath("$.content[1].message").value("Test 2"));
   }
 
   @Test

--- a/src/test/java/br/com/conectabyte/profissu/controllers/ReviewControllerTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/controllers/ReviewControllerTest.java
@@ -3,7 +3,9 @@ package br.com.conectabyte.profissu.controllers;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -28,8 +30,10 @@ import br.com.conectabyte.profissu.dtos.response.ReviewResponseDto;
 import br.com.conectabyte.profissu.properties.ProfissuProperties;
 import br.com.conectabyte.profissu.services.ReviewService;
 import br.com.conectabyte.profissu.services.security.SecurityRequestedServiceService;
+import br.com.conectabyte.profissu.services.security.SecurityReviewService;
 
-@WebMvcTest({ ReviewController.class, SecurityRequestedServiceService.class, ProfissuProperties.class })
+@WebMvcTest({ ReviewController.class, SecurityReviewService.class, SecurityRequestedServiceService.class,
+    ProfissuProperties.class })
 @Import(SecurityConfig.class)
 class ReviewControllerTest {
 
@@ -41,6 +45,9 @@ class ReviewControllerTest {
 
   @MockitoBean
   private ReviewService reviewService;
+
+  @MockitoBean
+  private SecurityReviewService securityReviewService;
 
   @MockitoBean
   private SecurityRequestedServiceService securityRequestedServiceService;
@@ -132,6 +139,17 @@ class ReviewControllerTest {
         .param("userId", "1")
         .param("isReviewOwner", "true"))
         .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  void shouldDeleteReviewSuccessfully() throws Exception {
+    doNothing().when(reviewService).deleteById(anyLong());
+
+    when(securityReviewService.ownershipCheck(any())).thenReturn(true);
+
+    mockMvc.perform(delete("/reviews/{id}", 1L))
+        .andExpect(status().isAccepted());
   }
 
   private org.springframework.test.web.servlet.ResultActions performPost(ReviewRequestDto request) throws Exception {

--- a/src/test/java/br/com/conectabyte/profissu/services/MessageServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/MessageServiceTest.java
@@ -62,7 +62,7 @@ class MessageServiceTest {
     final var serviceProvider = UserUtils.create();
     final var requestedService = RequestedServiceUtils.create(user, AddressUtils.create(user));
     final var conversation = ConversationUtils.create(user, serviceProvider, requestedService, List.of());
-    final var messageRequestDto = new MessageRequestDto("Teste");
+    final var messageRequestDto = new MessageRequestDto("Test");
 
     when(conversationService.findById(any())).thenReturn(conversation);
     when(jwtService.getClaims()).thenReturn(Optional.of(new HashMap<>(Map.of("sub", "1"))));
@@ -82,7 +82,7 @@ class MessageServiceTest {
     final var serviceProvider = UserUtils.create();
     final var requestedService = RequestedServiceUtils.create(user, AddressUtils.create(user));
     final var conversation = ConversationUtils.create(user, serviceProvider, requestedService, List.of());
-    final var messageRequestDto = new MessageRequestDto("Teste");
+    final var messageRequestDto = new MessageRequestDto("Test");
 
     conversation.setOfferStatus(OfferStatusEnum.ACCEPTED);
 
@@ -136,7 +136,7 @@ class MessageServiceTest {
     when(userService.findById(any())).thenThrow(new ResourceNotFoundException("User not found."));
 
     assertThrows(ResourceNotFoundException.class,
-        () -> messageService.sendMessage(1L, new MessageRequestDto("Teste")));
+        () -> messageService.sendMessage(1L, new MessageRequestDto("Test")));
   }
 
   @Test

--- a/src/test/java/br/com/conectabyte/profissu/services/security/SecurityReviewServiceTest.java
+++ b/src/test/java/br/com/conectabyte/profissu/services/security/SecurityReviewServiceTest.java
@@ -1,0 +1,65 @@
+package br.com.conectabyte.profissu.services.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import br.com.conectabyte.profissu.exceptions.ResourceNotFoundException;
+import br.com.conectabyte.profissu.services.ReviewService;
+import br.com.conectabyte.profissu.utils.ReviewUtils;
+import br.com.conectabyte.profissu.utils.UserUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class SecurityReviewServiceTest {
+
+  @Mock
+  private ReviewService reviewService;
+
+  @Mock
+  private SecurityService securityService;
+
+  @InjectMocks
+  private SecurityReviewService securityReviewService;
+
+  @Test
+  void shouldReturnTrueWhenUserIsOwnerOfReview() {
+    final var user = UserUtils.create();
+    final var review = ReviewUtils.create(user, null);
+
+    when(reviewService.findById(any())).thenReturn(review);
+    when(securityService.isOwner(any())).thenReturn(true);
+
+    final var isOwner = securityReviewService.ownershipCheck(1L);
+
+    assertTrue(isOwner);
+  }
+
+  @Test
+  void shouldReturnFalseWhenUserIsNotOwnerOfReview() {
+    final var user = UserUtils.create();
+    final var review = ReviewUtils.create(user, null);
+
+    when(reviewService.findById(any())).thenReturn(review);
+    when(securityService.isOwner(any())).thenReturn(false);
+
+    final var isOwner = securityReviewService.ownershipCheck(1L);
+
+    assertFalse(isOwner);
+  }
+
+  @Test
+  void shouldReturnFalseWhenReviewNotFound() {
+    when(reviewService.findById(any())).thenThrow(new ResourceNotFoundException("Review not found"));
+
+    final var isOwner = securityReviewService.ownershipCheck(1L);
+
+    assertFalse(isOwner);
+  }
+}

--- a/src/test/java/br/com/conectabyte/profissu/utils/MessageUtils.java
+++ b/src/test/java/br/com/conectabyte/profissu/utils/MessageUtils.java
@@ -8,7 +8,7 @@ public class MessageUtils {
   public static Message create(User user, Conversation conversation) {
     final var message = new Message();
 
-    message.setMessage("Teste");
+    message.setMessage("Test");
     message.setUser(user);
     message.setConversation(conversation);
 

--- a/src/test/java/br/com/conectabyte/profissu/utils/ReviewUtils.java
+++ b/src/test/java/br/com/conectabyte/profissu/utils/ReviewUtils.java
@@ -1,0 +1,19 @@
+package br.com.conectabyte.profissu.utils;
+
+import br.com.conectabyte.profissu.entities.RequestedService;
+import br.com.conectabyte.profissu.entities.Review;
+import br.com.conectabyte.profissu.entities.User;
+
+public class ReviewUtils {
+  public static Review create(User user, RequestedService requestedService) {
+    final var review = new Review();
+
+    review.setReview("Revew Test");
+    review.setStars(1);
+    review.setTitle("Title Test");
+    review.setUser(user);
+    review.setRequestedService(requestedService);
+
+    return review;
+  }
+}


### PR DESCRIPTION
### Description
This pull request adds functionality to allow users to delete feedback they have previously submitted, ensuring complete removal of the feedback record. It also includes corresponding tests and updates to the API documentation.

### Main Changes
- **add endpoint to delete feedback** — Implemented an endpoint that allows users to delete their own feedback permanently.
- **add unit tests for feedback deletion** — Created tests covering successful deletion and scenarios where feedback does not exist.
- **update API documentation** — Added details about the new feedback deletion endpoint, including request and response specifications.